### PR TITLE
Add pytest scaffold for Flask API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test lint
+
+# Run test suite with coverage
+test:
+	pytest --cov
+
+# Run linters (ruff and mypy)
+lint:
+	ruff backend/app tests
+	mypy backend/app tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,22 @@ quote-style = "preserve"
 indent-style = "space"
 line-ending = "lf"
 docstring-code-format = true
+
+[tool.pytest.ini_options]
+addopts = "-ra -q --strict-config --strict-markers --disable-warnings --cov=backend/app --cov=tests --cov-branch"
+testpaths = [
+  "tests",
+]
+python_files = "test_*.py"
+filterwarnings = [
+  "error::DeprecationWarning",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["backend/app", "tests"]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 90
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,60 @@
+# Test suite
+
+This directory contains the pytest-based tests for the FitnessTrack API.
+
+## Running tests
+
+```bash
+make test  # or simply: pytest
+```
+
+Coverage is enforced at 90%. To override the threshold (e.g., in CI) use
+``PYTEST_ADDOPTS="--cov-fail-under=80"``.
+
+## Fixtures
+
+- ``app`` – Flask application created with the testing config.
+- ``session`` – transactional SQLAlchemy session rolled back after each test.
+- ``client`` – Flask test client.
+- ``user`` / ``auth_token`` / ``auth_header`` – helpers for authenticated requests.
+- ``freeze_time`` – factory for deterministic timestamps using *freezegun*.
+
+Factories live in ``tests/factories`` and helpers in ``tests/helpers``.
+
+## Adding new factories
+
+Create a new module in ``tests/factories/`` inheriting from
+``SQLAlchemyFactory`` and set ``sqlalchemy_session = db.session``.
+
+## Adding endpoint tests
+
+Place files under ``tests/integration/`` named ``test_<resource>.py``.
+Follow the Arrange–Act–Assert pattern and prefer parametrization for
+variants.
+
+## Parallel execution
+
+The setup works with ``pytest-xdist``. Each worker uses its own database
+transaction; avoid global state.
+
+## Continuous Integration
+
+If using GitHub Actions, a minimal workflow could look like:
+
+```yaml
+# .github/workflows/tests.yml
+# name: tests
+# on: [push, pull_request]
+# jobs:
+#   tests:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions/setup-python@v5
+#         with:
+#           python-version: '3.12'
+#       - run: pip install -r backend/requirements.txt
+#       - run: pip install -r requirements-dev.txt  # if present
+#       - run: pytest
+```
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test suite package."""
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,132 @@
+"""Global pytest fixtures for the FitnessTrack API."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+from flask import Flask
+from sqlalchemy import event
+
+# Ensure the ``backend`` package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend"))
+
+from app import create_app  # noqa: E402
+from app.core.database import db  # noqa: E402
+from app.models.user import User  # noqa: E402
+
+from tests.factories.user import UserFactory  # noqa: E402
+from tests.helpers.auth import expired_token, issue_token  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def app() -> Generator[Flask, None, None]:
+    """Create and configure a Flask application for tests.
+
+    Returns
+    -------
+    Generator[Flask, None, None]
+        Configured Flask application instance.
+    """
+
+    os.environ.setdefault("APP_ENV", "testing")
+    application = create_app()
+    with application.app_context():
+        yield application
+
+
+@pytest.fixture(scope="session")
+def _db(app: Flask) -> Generator[Any, None, None]:
+    """Initialize the database schema for the test session."""
+
+    with app.app_context():
+        db.create_all()
+        yield db
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def session(_db: Any) -> Generator[Any, None, None]:
+    """Provide a transactional database session for a test case."""
+
+    connection = _db.engine.connect()
+    transaction = connection.begin()
+    sess = _db.create_scoped_session({"bind": connection, "binds": {}})
+    _db.session = sess
+
+    nested = connection.begin_nested()
+
+    @event.listens_for(sess(), "after_transaction_end")
+    def restart_savepoint(_: Any, trans: Any) -> None:  # pragma: no cover - event hook
+        if trans.nested and not trans._parent.nested:
+            nonlocal nested
+            nested = connection.begin_nested()
+
+    try:
+        yield sess
+    finally:
+        sess.remove()
+        transaction.rollback()
+        connection.close()
+
+
+@pytest.fixture()
+def client(app: Flask) -> Generator[Any, None, None]:
+    """Return a Flask test client."""
+
+    return app.test_client()
+
+
+@pytest.fixture()
+def user(session: Any) -> User:
+    """Persist and return a user instance."""
+
+    return UserFactory()
+
+
+@pytest.fixture()
+def auth_token(app: Flask, user: User) -> str:
+    """Generate a valid JWT for ``user``."""
+
+    with app.app_context():
+        return issue_token(user.id)
+
+
+@pytest.fixture()
+def auth_header(auth_token: str) -> dict[str, str]:
+    """Authorization header for authenticated requests."""
+
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+@pytest.fixture()
+def expired_auth_token(app: Flask, user: User) -> str:
+    """Return an already expired JWT for ``user``."""
+
+    with app.app_context():
+        return expired_token(user.id)
+
+
+@pytest.fixture()
+def freeze_time() -> Callable[[str | None], Any]:
+    """Factory returning :func:`freezegun.freeze_time`.
+
+    Examples
+    --------
+    >>> def test_with_frozen_time(freeze_time):
+    ...     with freeze_time("2024-01-01"):
+    ...         ...
+    """
+
+    from freezegun import freeze_time as _freeze_time
+
+    def _factory(target: str | None = None) -> Any:
+        return _freeze_time(target or "2024-01-01")
+
+    return _factory
+

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,6 @@
+# End-to-End tests
+
+Placeholder directory for future end-to-end scenarios. Tests here should
+exercise the application through the full HTTP stack against a running
+server instance.
+

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,18 @@
+"""Factory Boy setup for test data generation."""
+
+from __future__ import annotations
+
+import factory
+from faker import Faker
+
+faker = Faker()
+Faker.seed(1234)
+
+
+class SQLAlchemyFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Base factory for SQLAlchemy models."""
+
+    class Meta:
+        abstract = True
+        sqlalchemy_session_persistence = "flush"
+

--- a/tests/factories/user.py
+++ b/tests/factories/user.py
@@ -1,0 +1,22 @@
+"""Factories for user-related models."""
+
+from __future__ import annotations
+
+import factory
+
+from app.core.database import db
+from app.models.user import User
+
+from . import SQLAlchemyFactory, faker
+
+
+class UserFactory(SQLAlchemyFactory):
+    """Factory for :class:`app.models.user.User`."""
+
+    class Meta:
+        model = User
+        sqlalchemy_session = db.session
+
+    email = factory.LazyAttribute(lambda _: faker.unique.email())
+    password = factory.PostGenerationMethodCall("password", "password123")
+

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,2 @@
+"""Helper utilities for tests."""
+

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -1,0 +1,37 @@
+"""Assertion helper utilities for tests."""
+
+from __future__ import annotations
+
+
+def assert_json_keys(data: dict, required: set[str]) -> None:
+    """Ensure that all required keys are present in ``data``.
+
+    Parameters
+    ----------
+    data:
+        JSON object under test.
+    required:
+        Set of required keys that must exist in ``data``.
+
+    Raises
+    ------
+    AssertionError
+        If any required key is missing.
+    """
+
+    missing = required - data.keys()
+    assert not missing, f"Missing keys: {', '.join(sorted(missing))}"
+
+
+def assert_pagination(obj: dict) -> None:
+    """Validate a standard pagination response structure.
+
+    Parameters
+    ----------
+    obj:
+        JSON object representing a paginated response.
+    """
+
+    assert_json_keys(obj, {"items", "total", "page", "limit"})
+    assert isinstance(obj["items"], list)
+

--- a/tests/helpers/auth.py
+++ b/tests/helpers/auth.py
@@ -1,0 +1,44 @@
+"""Authentication helpers for tests."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from flask_jwt_extended import create_access_token
+
+
+def issue_token(identity: int, expires_delta: timedelta | None = None) -> str:
+    """Generate a JWT for ``identity``.
+
+    Parameters
+    ----------
+    identity:
+        Subject identifier to encode in the token.
+    expires_delta:
+        Optional expiry delta. If ``None``, the default expiry is used.
+
+    Returns
+    -------
+    str
+        Encoded JWT string.
+    """
+
+    return create_access_token(identity=identity, expires_delta=expires_delta)
+
+
+def expired_token(identity: int) -> str:
+    """Return an already expired JWT for ``identity``.
+
+    Parameters
+    ----------
+    identity:
+        Subject identifier to encode in the token.
+
+    Returns
+    -------
+    str
+        Encoded JWT string that has already expired.
+    """
+
+    return create_access_token(identity=identity, expires_delta=timedelta(seconds=-1))
+

--- a/tests/helpers/http.py
+++ b/tests/helpers/http.py
@@ -1,0 +1,46 @@
+"""HTTP helper utilities for tests."""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+
+def json_headers(auth_token: str | None = None) -> dict[str, str]:
+    """Return standard JSON headers.
+
+    Parameters
+    ----------
+    auth_token:
+        Optional bearer token to include.
+
+    Returns
+    -------
+    dict[str, str]
+        HTTP headers dictionary.
+    """
+
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    return headers
+
+
+def build_url(path: str, **query: str | int | float) -> str:
+    """Build a URL with encoded query parameters.
+
+    Parameters
+    ----------
+    path:
+        Base path of the endpoint.
+    **query:
+        Query parameters to append.
+
+    Returns
+    -------
+    str
+        Final URL string including encoded query string.
+    """
+
+    qs = urlencode({k: v for k, v in query.items() if v is not None})
+    return f"{path}?{qs}" if qs else path
+

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,29 @@
+"""Integration tests for authentication endpoints."""
+
+from __future__ import annotations
+
+
+def test_register_and_login(client) -> None:
+    """A user can register then obtain a JWT by logging in."""
+
+    payload = {"email": "user@example.com", "password": "secret123"}
+
+    # Register
+    resp = client.post("/api/v1/auth/register", json=payload)
+    assert resp.status_code == 201
+
+    # Login
+    resp = client.post("/api/v1/auth/login", json=payload)
+    assert resp.status_code == 200
+    assert "access_token" in resp.get_json()
+
+
+def test_me_endpoint_requires_auth(client, auth_header, user) -> None:
+    """Authenticated request to ``/me`` returns user info."""
+
+    resp = client.get("/api/v1/auth/me", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["id"] == user.id
+    assert data["email"] == user.email
+

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,0 +1,31 @@
+"""Basic smoke tests for the API."""
+
+from __future__ import annotations
+
+
+def test_healthz(client) -> None:
+    """Health endpoint returns a simple status payload."""
+
+    # Act
+    resp = client.get("/api/v1/healthz")
+
+    # Assert
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_readiness(client) -> None:
+    """Readiness endpoint indicates readiness."""
+
+    resp = client.get("/api/v1/readiness")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ready": True}
+
+
+def test_cors_headers(client) -> None:
+    """CORS headers should reflect allowed origins."""
+
+    resp = client.get("/api/v1/healthz", headers={"Origin": "http://localhost:5173"})
+    assert resp.status_code == 200
+    assert resp.headers["Access-Control-Allow-Origin"] == "http://localhost:5173"
+

--- a/tests/integration/test_users_crud.py
+++ b/tests/integration/test_users_crud.py
@@ -1,0 +1,60 @@
+"""Placeholder tests for future user CRUD endpoints."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.skip(reason="User CRUD endpoints not implemented yet")
+
+
+def test_create_user() -> None:
+    """Test creating a user.
+
+    TODO
+    ----
+    - 201 on success
+    - 422 on invalid payload
+    - 409 on duplicate email
+    """
+
+
+def test_read_user() -> None:
+    """Test retrieving a user.
+
+    TODO
+    ----
+    - 200 when found
+    - 404 when not found
+    """
+
+
+def test_update_user() -> None:
+    """Test updating a user.
+
+    TODO
+    ----
+    - 200/204 on success
+    - 422 on invalid payload
+    - 404 when missing
+    """
+
+
+def test_delete_user() -> None:
+    """Test deleting a user.
+
+    TODO
+    ----
+    - 204 on success
+    - subsequent 404 for idempotency
+    """
+
+
+def test_list_users() -> None:
+    """Test listing users with pagination and filters.
+
+    TODO
+    ----
+    - pagination fields
+    - sort and filter parameters
+    """
+

--- a/tests/unit/test_external_api.py
+++ b/tests/unit/test_external_api.py
@@ -1,0 +1,34 @@
+"""Example unit test demonstrating external HTTP mocking."""
+
+from __future__ import annotations
+
+import requests
+import responses
+
+
+def fetch_status() -> dict:
+    """Fetch JSON status from an external service."""
+
+    resp = requests.get("https://example.com/status", timeout=1)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@responses.activate
+def test_fetch_status_success() -> None:
+    """Example of mocking a successful HTTP call with ``responses``."""
+
+    # Arrange
+    responses.add(
+        responses.GET,
+        "https://example.com/status",
+        json={"ok": True},
+        status=200,
+    )
+
+    # Act
+    data = fetch_status()
+
+    # Assert
+    assert data == {"ok": True}
+

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,18 @@
+"""Unit tests for the logging utility."""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.logger import configure_logging
+
+
+def test_configure_logging_sets_level() -> None:
+    """``configure_logging`` should set the root logger level."""
+
+    # Act
+    configure_logging("DEBUG")
+
+    # Assert
+    assert logging.getLogger().level == logging.DEBUG
+


### PR DESCRIPTION
## Summary
- add pytest-based testing scaffold with app factory, DB session, and JWT fixtures
- provide factory-boy models, helpers, and example integration/unit tests
- configure coverage, pytest options, and Makefile commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_jwt_extended')*

------
https://chatgpt.com/codex/tasks/task_e_68b21f3861ac832595cd8adb1fcd456a