### PR TITLE
Add documentation for backend modules and tests

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,8 @@
-"""Expose the application factory at package level."""
+"""Expose the application factory at package level.
+
+Provide convenient access to :func:`app.factory.create_app` so callers can
+``from app import create_app`` without traversing the package structure.
+"""
 
 from __future__ import annotations
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,4 +1,4 @@
-"""API blueprint package."""
+"""API blueprint package aggregating versioned endpoints."""
 
 from __future__ import annotations
 
@@ -13,12 +13,23 @@ def register_blueprint_group(
     base_prefix: str,
     entries: Iterable[tuple[Blueprint, str]],
 ) -> None:
-    """
-    Register a group of blueprints under a common base prefix.
+    """Register related blueprints beneath a common prefix.
 
-    :param app: Flask application.
-    :param base_prefix: Base prefix (e.g. '/api/v1').
-    :param entries: Iterable of (blueprint, relative_prefix).
+    Parameters
+    ----------
+    app: flask.Flask
+        Application instance receiving the blueprints.
+    base_prefix: str
+        Prefix applied to all entries, typically the API version segment such
+        as ``"/api/v1"``.
+    entries: Iterable[tuple[flask.Blueprint, str]]
+        Iterable of ``(blueprint, relative_prefix)`` pairs where
+        ``relative_prefix`` is appended to ``base_prefix``.
+
+    Notes
+    -----
+    Empty relative prefixes are supported, allowing a blueprint to mount at the
+    version root while others extend it with additional path segments.
     """
     for bp, rel_prefix in entries:
         # Normalize slashes safely
@@ -30,8 +41,17 @@ def register_blueprint_group(
 
 
 def init_app(app: Flask) -> None:
-    """
-    Register all API versions.
+    """Register the available API versions on the Flask app.
+
+    Parameters
+    ----------
+    app: flask.Flask
+        Application instance to wire with blueprints.
+
+    Notes
+    -----
+    The base prefix defaults to ``"/api"`` but can be overridden via the
+    ``API_BASE_PREFIX`` configuration key.
     """
     api_base = app.config.get("API_BASE_PREFIX", "/api")
 

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,4 +1,4 @@
-"""API v1 blueprint package."""
+"""API v1 blueprint package bundling authentication and health routes."""
 
 from __future__ import annotations
 

--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -1,4 +1,4 @@
-"""Health and readiness endpoints."""
+"""Health and readiness endpoints for uptime checks."""
 
 from __future__ import annotations
 
@@ -9,23 +9,28 @@ bp = Blueprint("health", __name__)
 
 @bp.get("/healthz")
 def healthz():
-    """Liveness probe endpoint.
+    """Report basic process health for liveness probes.
 
     Returns
     -------
-    dict
-        Simple status payload.
+    dict[str, str]
+        Payload containing a static ``status`` field with value ``"ok"``.
     """
     return {"status": "ok"}
 
 
 @bp.get("/readiness")
 def readiness():
-    """Readiness probe endpoint.
+    """Indicate the service is ready to handle traffic.
 
     Returns
     -------
-    dict
-        Simple readiness payload (we can expand with DB checks later).
+    dict[str, bool]
+        Payload containing ``ready`` to signal readiness to orchestrators.
+
+    Notes
+    -----
+    No downstream health checks are performed yet; the endpoint only reflects
+    process-level readiness.
     """
     return {"ready": True}

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application utilities including config, extensions, and error glue."""

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -17,7 +17,21 @@ load_dotenv()
 
 
 def env_bool(name: str, default: bool = False) -> bool:
-    """Parse bools from environment variables."""
+    """Parse a boolean flag from an environment variable.
+
+    Parameters
+    ----------
+    name: str
+        Environment variable to inspect.
+    default: bool, optional
+        Value returned when the variable is unset. Defaults to ``False``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the value resembles ``{"1", "true", "yes", "y", "on"}``
+        ignoring case; otherwise ``False`` or ``default`` when missing.
+    """
     val = os.getenv(name)
     if val is None:
         return default
@@ -25,7 +39,41 @@ def env_bool(name: str, default: bool = False) -> bool:
 
 
 class BaseConfig:
-    """Base configuration shared across environments."""
+    """Base configuration shared across environments.
+
+    Attributes
+    ----------
+    API_BASE_PREFIX: str
+        Root path for registering API blueprints.
+    SECRET_KEY: str
+        Flask secret used for session signing. Defaults to a development-safe
+        placeholder and should be overridden in production.
+    JWT_SECRET_KEY: str
+        Key used by ``flask-jwt-extended`` for signing access tokens.
+    SQLALCHEMY_DATABASE_URI: str
+        Database connection string consumed by SQLAlchemy.
+    SQLALCHEMY_TRACK_MODIFICATIONS: bool
+        Disabled to avoid extra overhead from the event system.
+    SQLALCHEMY_ECHO: bool
+        When ``True`` SQLAlchemy logs SQL statements for debugging.
+    JSON_SORT_KEYS: bool
+        Keeps JSON output order stable when ``False``.
+    PROPAGATE_EXCEPTIONS: bool
+        Controls Flask error propagation.
+    LOG_LEVEL: str
+        Root logging verbosity (``INFO`` by default).
+    CORS_ORIGINS: str
+        Comma-separated list of allowed origins for CORS.
+    DEBUG: bool
+        Toggles Flask debug mode.
+    TESTING: bool
+        Enables Flask testing mode when ``True``.
+
+    Notes
+    -----
+    Values are primarily sourced from environment variables, enabling
+    configuration without code changes.
+    """
 
     API_BASE_PREFIX = "/api"
 
@@ -52,7 +100,13 @@ class BaseConfig:
 
 
 class DevelopmentConfig(BaseConfig):
-    """Development-friendly config."""
+    """Configuration tailored for local development.
+
+    Notes
+    -----
+    Enables debug mode by default and honors ``SQLALCHEMY_ECHO`` for verbose
+    SQL logging when requested.
+    """
 
     DEBUG = env_bool("FLASK_DEBUG", True)
     SQLALCHEMY_ECHO = env_bool("SQLALCHEMY_ECHO", False)
@@ -60,7 +114,14 @@ class DevelopmentConfig(BaseConfig):
 
 
 class TestingConfig(BaseConfig):
-    """Testing config: in-memory DB by default."""
+    """Configuration for automated test runs.
+
+    Notes
+    -----
+    - Forces ``TESTING`` mode and disables debug logs.
+    - Uses an in-memory SQLite database unless ``TEST_DATABASE_URL`` is set.
+    - Propagates exceptions so pytest can surface tracebacks directly.
+    """
 
     TESTING = True
     DEBUG = False
@@ -70,7 +131,13 @@ class TestingConfig(BaseConfig):
 
 
 class ProductionConfig(BaseConfig):
-    """Production config."""
+    """Configuration defaults for production deployments.
+
+    Notes
+    -----
+    Keeps debug and SQL echoing disabled while relying on WSGI-level log
+    configuration for noise control.
+    """
 
     DEBUG = False
     SQLALCHEMY_ECHO = False
@@ -86,10 +153,17 @@ CONFIG_MAP: Mapping[str, type[BaseConfig]] = {
 
 
 def get_config() -> type[BaseConfig]:
-    """Return the selected config class based on ``APP_ENV``.
+    """Return the configuration class inferred from ``APP_ENV``.
 
-    :returns: Configuration class to pass to ``app.config.from_object``.
-    :rtype: Type[BaseConfig]
+    Returns
+    -------
+    type[BaseConfig]
+        Class to pass to :meth:`flask.Config.from_object`.
+
+    Notes
+    -----
+    Falls back to :class:`DevelopmentConfig` when ``APP_ENV`` is unset or
+    unknown.
     """
     name = os.getenv(ENV_VAR, "development").strip().lower()
     return CONFIG_MAP.get(name, DevelopmentConfig)

--- a/backend/app/core/cors.py
+++ b/backend/app/core/cors.py
@@ -1,3 +1,5 @@
+"""CORS configuration helper for API resources."""
+
 from __future__ import annotations
 
 from flask import Flask
@@ -5,11 +7,14 @@ from flask_cors import CORS
 
 
 def init_app(app: Flask) -> None:
-    """
-    Configure CORS policy for /api/*.
+    """Configure CORS for API endpoints based on application config.
 
-    :param app: Flask application.
-    :type app: Flask
+    Parameters
+    ----------
+    app: flask.Flask
+        Application whose ``CORS_ORIGINS`` and ``CORS_MAX_AGE`` settings are
+        consulted. When ``CORS_ORIGINS`` is blank or ``"*"`` the policy allows
+        any origin but disables credential support.
     """
     raw_origins = app.config.get("CORS_ORIGINS", "")
     origins = [o.strip() for o in raw_origins.split(",") if o.strip()]

--- a/backend/app/core/extensions.py
+++ b/backend/app/core/extensions.py
@@ -1,3 +1,5 @@
+"""Global Flask extension instances and initialization helpers."""
+
 from __future__ import annotations
 
 from flask import Flask
@@ -12,11 +14,14 @@ jwt = JWTManager()
 
 
 def init_app(app: Flask) -> None:
-    """
-    Initialize Flask extensions.
+    """Initialize SQLAlchemy, migrations, and JWT extensions.
 
-    :param app: Flask application.
-    :type app: Flask
+    Parameters
+    ----------
+    app: flask.Flask
+        Application used to bind extension instances. This call imports the
+        :mod:`app.models` package to ensure SQLAlchemy metadata is ready for
+        migrations.
     """
     db.init_app(app)
 

--- a/backend/app/core/logger.py
+++ b/backend/app/core/logger.py
@@ -1,4 +1,4 @@
-"""Logging configuration utilities."""
+"""Logging configuration utilities for the application factory."""
 
 from __future__ import annotations
 
@@ -7,16 +7,18 @@ import sys
 
 
 def configure_logging(level: str = "INFO") -> None:
-    """Configure root logger with a simple stdout handler.
+    """Configure the root logger with a stdout handler.
 
     Parameters
     ----------
-    level:
-        String log level (e.g., "DEBUG", "INFO", "WARNING").
+    level: str, optional
+        Logging level name such as ``"DEBUG"`` or ``"INFO"``. The value is
+        uppercased before being applied.
 
-    Returns
-    -------
-    None
+    Notes
+    -----
+    Existing root handlers are cleared before installing the new handler to
+    avoid duplicate log lines when the app factory is invoked multiple times.
     """
     handler = logging.StreamHandler(sys.stdout)
     fmt = logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s", "%Y-%m-%dT%H:%M:%S")

--- a/backend/app/core/proxy.py
+++ b/backend/app/core/proxy.py
@@ -1,3 +1,5 @@
+"""WSGI proxy middleware configuration helper."""
+
 from __future__ import annotations
 
 from flask import Flask
@@ -5,8 +7,17 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 def init_app(app: Flask) -> None:
-    """
-    Apply ProxyFix if configured.
+    """Apply :class:`werkzeug.middleware.proxy_fix.ProxyFix` when enabled.
+
+    Parameters
+    ----------
+    app: flask.Flask
+        Application whose WSGI pipeline should respect upstream proxy headers.
+
+    Notes
+    -----
+    Controlled by the ``USE_PROXYFIX`` configuration flag (defaults to
+    ``True``). ``ProxyFix`` trusts a single hop for ``X-Forwarded-*`` headers.
     """
     if app.config.get("USE_PROXYFIX", True):
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)

--- a/backend/app/factory.py
+++ b/backend/app/factory.py
@@ -1,3 +1,5 @@
+"""Application factory wiring Flask extensions and blueprints."""
+
 from __future__ import annotations
 
 from flask import Flask
@@ -12,6 +14,35 @@ def create_app(
     instance_relative_config: bool = True,
     instance_config_filename: str = "config.py",
 ) -> Flask:
+    """Build and configure the Flask application.
+
+    Parameters
+    ----------
+    config: str | type[BaseConfig] | object | None, optional
+        Explicit configuration object or import string. ``None`` selects the
+        configuration from :func:`app.core.config.get_config` using
+        ``APP_ENV``.
+    instance_relative_config: bool, optional
+        Whether to resolve instance configuration files relative to
+        ``instance_path``. Defaults to ``True`` to support per-deployment
+        overrides.
+    instance_config_filename: str, optional
+        Name of the optional instance configuration file loaded via
+        :meth:`flask.Config.from_pyfile`.
+
+    Returns
+    -------
+    flask.Flask
+        Fully initialized application with extensions, CORS, proxies, API, and
+        error handlers registered.
+
+    Notes
+    -----
+    - Logging is configured eagerly so early failures are captured.
+    - The application will attempt to load ``instance_config_filename`` even
+      when ``config`` is provided unless ``instance_relative_config`` is
+      ``False``.
+    """
     app = Flask(__name__, instance_relative_config=instance_relative_config)
 
     # Config

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,4 @@
-"""Model package init used by Alembic autogenerate."""
+"""Expose SQLAlchemy models for Alembic autogeneration and app imports."""
 
 from .base import db
 from .exercise import Exercise, MuscleGroup

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,3 +1,5 @@
+"""Reusable SQLAlchemy mixins shared by domain models."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -6,10 +8,14 @@ from app.core.extensions import db
 
 
 class TimestampMixin:
-    """Common timestamps mixin.
+    """Provide ``created_at`` and ``updated_at`` timestamp columns.
 
-    :ivar created_at: Creation datetime in UTC.
-    :ivar updated_at: Last update datetime in UTC.
+    Attributes
+    ----------
+    created_at: sqlalchemy.sql.schema.Column
+        UTC timestamp filled on insert.
+    updated_at: sqlalchemy.sql.schema.Column
+        UTC timestamp refreshed on updates via SQLAlchemy ``onupdate``.
     """
 
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
@@ -19,16 +25,19 @@ class TimestampMixin:
 
 
 class PKMixin:
-    """Primary key mixin.
+    """Expose an integer surrogate primary key column named ``id``.
 
-    :ivar id: Surrogate integer primary key.
+    Attributes
+    ----------
+    id: sqlalchemy.sql.schema.Column
+        Auto-incrementing integer primary key managed by the database.
     """
 
     id = db.Column(db.Integer, primary_key=True)
 
 
 class ReprMixin:
-    """Human-friendly __repr__ mixin."""
+    """Provide a concise ``__repr__`` including the class name and id."""
 
     def __repr__(self) -> str:
         # Short and useful representation for debugging

--- a/backend/app/models/exercise.py
+++ b/backend/app/models/exercise.py
@@ -1,3 +1,5 @@
+"""Exercise catalog models and enumerations."""
+
 from __future__ import annotations
 
 import enum
@@ -8,7 +10,7 @@ from .base import PKMixin, ReprMixin, TimestampMixin
 
 
 class MuscleGroup(enum.Enum):
-    """Supported muscle groups."""
+    """Enumerate supported primary muscle groups for cataloged exercises."""
 
     CHEST = "CHEST"
     BACK = "BACK"
@@ -25,13 +27,24 @@ class MuscleGroup(enum.Enum):
 
 
 class Exercise(PKMixin, TimestampMixin, ReprMixin, db.Model):
-    """Exercise catalog entity.
+    """Represent a catalog entry describing a physical exercise.
 
-    :ivar id: Primary key.
-    :ivar name: Unique exercise name.
-    :ivar muscle_group: Main muscle group (enum).
-    :ivar is_unilateral: Whether exercise is unilateral.
-    :ivar notes: Free-form notes.
+    Attributes
+    ----------
+    id: int
+        Surrogate primary key.
+    name: str
+        Unique exercise name indexed for quick lookups.
+    muscle_group: MuscleGroup
+        Dominant muscle group targeted by the movement.
+    is_unilateral: bool
+        Indicates whether the movement is performed one side at a time.
+    notes: str | None
+        Optional free-form instructions or cues.
+    routine_items: list[RoutineExercise]
+        Reverse relationship to routine prescriptions that use the exercise.
+    workout_items: list[WorkoutExercise]
+        Reverse relationship to performed workouts containing the exercise.
     """
 
     __tablename__ = "exercises"

--- a/backend/app/models/routine.py
+++ b/backend/app/models/routine.py
@@ -1,3 +1,5 @@
+"""Workout routine template models."""
+
 from __future__ import annotations
 
 from sqlalchemy import UniqueConstraint
@@ -8,12 +10,22 @@ from .base import PKMixin, ReprMixin, TimestampMixin
 
 
 class Routine(PKMixin, TimestampMixin, ReprMixin, db.Model):
-    """User routine template.
+    """Represent a reusable template of exercises planned by a user.
 
-    :ivar id: Primary key.
-    :ivar user_id: Owner user id.
-    :ivar name: Routine name.
-    :ivar notes: Routine notes.
+    Attributes
+    ----------
+    id: int
+        Surrogate primary key.
+    user_id: int
+        Foreign key referencing the owning :class:`app.models.user.User`.
+    name: str
+        Display name of the routine.
+    notes: str | None
+        Optional notes describing the intent of the routine.
+    user: app.models.user.User
+        ORM relationship back to the owning user.
+    exercises: list[RoutineExercise]
+        Ordered collection of prescribed exercises including set/rep targets.
     """
 
     __tablename__ = "routines"
@@ -38,16 +50,30 @@ class Routine(PKMixin, TimestampMixin, ReprMixin, db.Model):
 
 
 class RoutineExercise(PKMixin, TimestampMixin, ReprMixin, db.Model):
-    """Exercise prescription inside a routine.
+    """Describe how an exercise should be performed within a routine.
 
-    :ivar id: Primary key.
-    :ivar routine_id: Parent routine id.
-    :ivar exercise_id: Exercise reference.
-    :ivar order: Display order (1-based).
-    :ivar target_sets: Planned number of sets.
-    :ivar target_reps: Planned reps per set (generic).
-    :ivar target_rpe: Planned RPE (nullable).
-    :ivar rest_sec: Planned rest time between sets in seconds.
+    Attributes
+    ----------
+    id: int
+        Surrogate primary key.
+    routine_id: int
+        Foreign key referencing the owning :class:`Routine`.
+    exercise_id: int
+        Foreign key pointing to the catalog :class:`app.models.exercise.Exercise`.
+    order: int
+        One-based display order enforced per routine via unique constraint.
+    target_sets: int
+        Suggested number of sets per session.
+    target_reps: int
+        Suggested number of repetitions per set.
+    target_rpe: float | None
+        Optional target rate of perceived exertion.
+    rest_sec: int
+        Planned rest duration between sets in seconds.
+    routine: Routine
+        Relationship back to the routine template.
+    exercise: app.models.exercise.Exercise
+        Relationship to the exercise catalog entry.
     """
 
     __tablename__ = "routine_exercises"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,4 +1,4 @@
-"""User model definition."""
+"""User model definition supporting password hashing for JWT auth."""
 
 from __future__ import annotations
 
@@ -12,18 +12,26 @@ from .base import PKMixin, ReprMixin, TimestampMixin
 
 
 class User(PKMixin, TimestampMixin, ReprMixin, db.Model):
-    """Minimal user entity (later extended for JWT auth).
+    """Minimal user entity used for authentication and ownership.
 
     Attributes
     ----------
-    id:
-        Primary key.
-    email:
-        Unique email address.
-    password_hash:
-        Hashed user password.
-    created_at:
-        Creation timestamp.
+    id: int
+        Surrogate primary key.
+    email: str
+        Unique login identifier validated at the database level.
+    name: str
+        Display name stored alongside the email address.
+    password_hash: str
+        Hash computed by :func:`werkzeug.security.generate_password_hash`.
+    created_at: datetime.datetime
+        Timestamp set when the record is inserted.
+    updated_at: datetime.datetime
+        Timestamp refreshed whenever the record mutates.
+    routines: list[app.models.routine.Routine]
+        Collection of routine templates owned by the user.
+    workouts: list[app.models.workout.Workout]
+        Collection of recorded workouts associated with the user.
     """
 
     __tablename__ = "users"
@@ -38,14 +46,44 @@ class User(PKMixin, TimestampMixin, ReprMixin, db.Model):
 
     @property
     def password(self) -> str:
-        """Prevent reading the raw password."""
+        """Prevent reading the raw password.
+
+        Raises
+        ------
+        AttributeError
+            Always raised to prevent disclosure of secret credentials.
+
+        Notes
+        -----
+        The property is intentionally write-only; use :meth:`verify_password`
+        to check credentials instead of reading them back.
+        """
         raise AttributeError("password is write-only")
 
     @password.setter
     def password(self, value: str) -> None:
-        """Hash and store the password."""
+        """Hash and store the password.
+
+        Parameters
+        ----------
+        value: str
+            Plaintext password which will be transformed using
+            :func:`werkzeug.security.generate_password_hash`.
+        """
         self.password_hash = generate_password_hash(value)
 
     def verify_password(self, value: str) -> bool:
-        """Check a plaintext password against the stored hash."""
+        """Check a plaintext password against the stored hash.
+
+        Parameters
+        ----------
+        value: str
+            Password candidate provided by a client.
+
+        Returns
+        -------
+        bool
+            ``True`` when the candidate matches ``password_hash``;
+            ``False`` otherwise.
+        """
         return cast(bool, check_password_hash(self.password_hash, value))

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,4 +1,4 @@
-"""Schema utilities and exports."""
+"""Schema utilities centralizing Marshmallow helpers and exports."""
 
 from __future__ import annotations
 
@@ -10,14 +10,19 @@ from app.core.errors import APIError
 
 
 def load_data(schema: Schema, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate *data* against *schema* and return result.
+    """Validate a payload using the provided schema and return the result.
 
     Parameters
     ----------
-    schema:
-        An instance of a Marshmallow :class:`Schema`.
-    data:
-        The input payload to validate.
+    schema: marshmallow.Schema
+        Schema instance used to deserialize and validate the payload.
+    data: dict[str, Any]
+        Raw request payload typically obtained from ``request.get_json``.
+
+    Returns
+    -------
+    dict[str, Any]
+        Deserialized payload produced by ``schema.load``.
 
     Raises
     ------

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,4 +1,4 @@
-"""Schemas for authentication endpoints."""
+"""Marshmallow schemas backing authentication endpoints."""
 
 from __future__ import annotations
 
@@ -6,14 +6,14 @@ from marshmallow import Schema, fields, validate
 
 
 class RegisterSchema(Schema):
-    """Validate payload for user registration."""
+    """Validate incoming registration payloads."""
 
     email = fields.Email(required=True)
     password = fields.String(required=True, validate=validate.Length(min=8))
 
 
 class LoginSchema(Schema):
-    """Validate payload for user login."""
+    """Validate incoming login payloads."""
 
     email = fields.Email(required=True)
     password = fields.String(required=True)

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Pytest suite package for backend components."""

--- a/backend/tests/factories/__init__.py
+++ b/backend/tests/factories/__init__.py
@@ -1,28 +1,33 @@
-# backend/tests/factories/__init__.py
+"""Factory Boy base classes and helpers for tests."""
+
 from __future__ import annotations
 
 import factory
 
 
 class SQLAlchemySession:
+    """Store the active SQLAlchemy session used by Factory Boy factories."""
+
     _session = None
 
     @classmethod
     def set(cls, session):
+        """Register the session that factories should use for persistence."""
         cls._session = session
 
     @classmethod
     def get(cls):
+        """Return the registered session or raise if missing."""
         if cls._session is None:
             raise RuntimeError("Factories session not set. Did you pass the 'session' fixture?")
         return cls._session
 
 
 class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Base class ensuring factories share the pytest-managed session."""
+
     class Meta:
         abstract = True
-        # ❌ Antes:
-        # sqlalchemy_session = SQLAlchemySession.get
-        # ✅ Después (pasar *callable*):
+        # ``sqlalchemy_session_factory`` expects a callable returning the session.
         sqlalchemy_session_factory = SQLAlchemySession.get
         sqlalchemy_session_persistence = "flush"

--- a/backend/tests/factories/exercise.py
+++ b/backend/tests/factories/exercise.py
@@ -1,4 +1,4 @@
-"""Factories for Exercise-related models."""
+"""Factory Boy definitions for exercise-related models."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from tests.factories import BaseFactory
 
 
 class ExerciseFactory(BaseFactory):
-    """Factory for the `Exercise` model."""
+    """Build persisted :class:`app.models.exercise.Exercise` instances."""
 
     class Meta:
         model = Exercise

--- a/backend/tests/factories/routine.py
+++ b/backend/tests/factories/routine.py
@@ -1,4 +1,4 @@
-"""Factories for Routine and RoutineExercise models."""
+"""Factory Boy definitions for routine templates and exercises."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from tests.factories.user import UserFactory
 
 
 class RoutineFactory(BaseFactory):
-    """Factory for the `Routine` model."""
+    """Build persisted :class:`app.models.routine.Routine` instances."""
 
     class Meta:
         model = Routine
@@ -23,7 +23,7 @@ class RoutineFactory(BaseFactory):
 
 
 class RoutineExerciseFactory(BaseFactory):
-    """Factory for the `RoutineExercise` model."""
+    """Build :class:`app.models.routine.RoutineExercise` prescriptions."""
 
     class Meta:
         model = RoutineExercise
@@ -32,10 +32,10 @@ class RoutineExerciseFactory(BaseFactory):
     routine = factory.SubFactory(RoutineFactory)  # sets routine_id automatically
     exercise = factory.SubFactory(ExerciseFactory)  # sets exercise_id automatically
 
-    # display order within routine (1-based)
+    # Display order within the routine (1-based)
     order = factory.Sequence(lambda n: n + 1)
 
-    # defaults aligned with model
+    # Defaults aligned with model constraints
     target_sets = 3
     target_reps = 10
     target_rpe = None

--- a/backend/tests/factories/user.py
+++ b/backend/tests/factories/user.py
@@ -1,4 +1,4 @@
-"""Factories for User-related models."""
+"""Factory Boy definitions for user entities used across tests."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from tests.factories import BaseFactory
 
 
 class UserFactory(BaseFactory):
-    """Factory for the `User` model."""
+    """Build persisted :class:`app.models.user.User` instances."""
 
     class Meta:
         model = User
@@ -21,7 +21,19 @@ class UserFactory(BaseFactory):
 
     @factory.post_generation
     def password(obj, create, extracted, **kwargs):
-        """Set password using the model's property for proper hashing."""
+        """Set the password using the model's property for proper hashing.
+
+        Parameters
+        ----------
+        obj: app.models.user.User
+            Instance being initialized by Factory Boy.
+        create: bool
+            Indicates whether the object was actually persisted.
+        extracted: str | None
+            Optional password override supplied by the factory call.
+        **kwargs: dict[str, object]
+            Unused additional keyword arguments from Factory Boy.
+        """
         value = extracted or "Passw0rd!"
         # Use model's setter so we test the domain logic
         obj.password = value

--- a/backend/tests/factories/workout.py
+++ b/backend/tests/factories/workout.py
@@ -1,4 +1,4 @@
-"""Factories for Workout, WorkoutExercise, and WorkoutSet models."""
+"""Factory Boy definitions for workout tracking models."""
 
 from __future__ import annotations
 
@@ -13,22 +13,21 @@ from tests.factories.user import UserFactory
 
 
 class WorkoutFactory(BaseFactory):
-    """Factory for the `Workout` model."""
+    """Build persisted :class:`app.models.workout.Workout` instances."""
 
     class Meta:
         model = Workout
 
     id = None
     user = factory.SubFactory(UserFactory)  # sets user_id
-    # routine is optional; si quieres cubrirlo en casos concretos:
-    # routine = factory.SubFactory(RoutineFactory)
-    # date -> dejamos que lo ponga el default del modelo (date.today)
+    # Routine is optional; override in tests that need an explicit association.
+    # date -> allow the model default (date.today) to populate the field.
     duration_min = None
     notes = factory.Faker("sentence", nb_words=8)
 
 
 class WorkoutExerciseFactory(BaseFactory):
-    """Factory for the `WorkoutExercise` model."""
+    """Build :class:`app.models.workout.WorkoutExercise` instances."""
 
     class Meta:
         model = WorkoutExercise
@@ -41,7 +40,7 @@ class WorkoutExerciseFactory(BaseFactory):
 
 
 class WorkoutSetFactory(BaseFactory):
-    """Factory for the `WorkoutSet` model."""
+    """Build :class:`app.models.workout.WorkoutSet` instances."""
 
     class Meta:
         model = WorkoutSet

--- a/backend/tests/helpers/utils.py
+++ b/backend/tests/helpers/utils.py
@@ -7,12 +7,17 @@ from contextlib import contextmanager
 
 @contextmanager
 def not_raises(exception: type[BaseException]):
-    """Context manager asserting that an exception is *not* raised.
+    """Assert that the wrapped block does not raise a given exception.
 
     Parameters
     ----------
-    exception:
-        Exception type that should not be raised.
+    exception: type[BaseException]
+        Exception type that must not occur within the context manager.
+
+    Raises
+    ------
+    AssertionError
+        If ``exception`` is raised by the wrapped block.
     """
     try:
         yield

--- a/backend/tests/unit/test_model_exercise.py
+++ b/backend/tests/unit/test_model_exercise.py
@@ -1,4 +1,4 @@
-"""Unit tests for the `Exercise` model."""
+"""Unit tests covering constraints and defaults on the Exercise model."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ class TestExerciseModel:
 
     @pytest.mark.unit
     def test_create_basic_exercise(self, session):
-        """Factory should create a valid exercise with defaults."""
+        """Arrange an exercise via the factory, insert it, and assert defaults persist."""
         e = ExerciseFactory()
         session.add(e)
         session.flush()
@@ -26,7 +26,7 @@ class TestExerciseModel:
 
     @pytest.mark.unit
     def test_name_unique(self, session):
-        """Exercise name should be unique."""
+        """Arrange two exercises sharing a name, flush, and expect an integrity error."""
         _ = ExerciseFactory(name="Squat", muscle_group=MuscleGroup.QUADS)
         session.flush()
 
@@ -36,7 +36,7 @@ class TestExerciseModel:
 
     @pytest.mark.unit
     def test_muscle_group_required(self, session):
-        """muscle_group must not be NULL."""
+        """Arrange an exercise missing ``muscle_group``, flush, and assert the DB rejects it."""
         e = Exercise(name="Deadlift", muscle_group=None)
         session.add(e)
         with pytest.raises(IntegrityError):
@@ -44,7 +44,7 @@ class TestExerciseModel:
 
     @pytest.mark.unit
     def test_is_unilateral_default_false(self, session):
-        """is_unilateral should default to False if not set."""
+        """Arrange an exercise without overriding ``is_unilateral``, flush, and confirm it defaults to ``False``."""
         e = ExerciseFactory(is_unilateral=None)  # factory override
         session.add(e)
         session.flush()

--- a/backend/tests/unit/test_model_exercise.py
+++ b/backend/tests/unit/test_model_exercise.py
@@ -44,7 +44,12 @@ class TestExerciseModel:
 
     @pytest.mark.unit
     def test_is_unilateral_default_false(self, session):
-        """Arrange an exercise without overriding ``is_unilateral``, flush, and confirm it defaults to ``False``."""
+        """Confirm default unilateral flag persists.
+
+        Arrange with a factory exercise using the default field.
+        Act by flushing the session.
+        Assert the stored value resolves to ``False``.
+        """
         e = ExerciseFactory(is_unilateral=None)  # factory override
         session.add(e)
         session.flush()

--- a/backend/tests/unit/test_model_routine.py
+++ b/backend/tests/unit/test_model_routine.py
@@ -1,4 +1,4 @@
-"""Unit tests for `Routine` and `RoutineExercise` models."""
+"""Unit tests validating Routine and RoutineExercise persistence rules."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ class TestRoutineModel:
 
     @pytest.mark.unit
     def test_create_basic_routine(self, session):
-        """Factory should create a valid routine with owner and timestamps."""
+        """Arrange a routine via the factory, flush it, and assert ownership and timestamps exist."""
         r = RoutineFactory()
         session.add(r)
         session.flush()
@@ -27,7 +27,7 @@ class TestRoutineModel:
 
     @pytest.mark.unit
     def test_name_required(self, session):
-        """`name` is NOT NULL."""
+        """Arrange a routine missing ``name``, attempt to flush, and verify the database rejects it."""
         u = UserFactory()
         session.add(u)
         session.flush()
@@ -38,7 +38,7 @@ class TestRoutineModel:
 
     @pytest.mark.unit
     def test_user_required(self, session):
-        """`user_id` is NOT NULL."""
+        """Arrange a routine without ``user_id``, flush, and ensure integrity enforcement triggers."""
         session.add(Routine(user_id=None, name="No owner"))
         with pytest.raises(IntegrityError):
             session.flush()
@@ -49,7 +49,7 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_create_basic_routine_exercise(self, session):
-        """Factory should create a valid routine exercise with defaults."""
+        """Arrange a routine exercise via the factory, flush, and assert defaults and relationships are populated."""
         rx = RoutineExerciseFactory()
         session.add(rx)
         session.flush()
@@ -69,7 +69,7 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_order_unique_within_routine(self, session):
-        """(routine_id, order) must be unique within a routine."""
+        """Arrange two routine exercises sharing an order, flush, and expect a uniqueness violation."""
         r = RoutineFactory()
         e1 = ExerciseFactory(name="Bench Press")
         e2 = ExerciseFactory(name="Incline Bench")
@@ -86,7 +86,7 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_same_order_allowed_in_different_routines(self, session):
-        """Same `order` is allowed across different routines."""
+        """Arrange exercises in separate routines with the same order, flush both, and confirm the constraint allows it."""
         r1 = RoutineFactory(name="A")
         r2 = RoutineFactory(name="B")
         ex = ExerciseFactory(name="Row")
@@ -102,7 +102,7 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_relationship_ordering_by_order(self, session):
-        """Routine.exercises should be ordered by `order` as declared in relationship."""
+        """Arrange out-of-order inserts, access the relationship, and assert ordering follows the ``order`` column."""
         r = RoutineFactory()
         e1 = ExerciseFactory(name="Lat Pulldown")
         e2 = ExerciseFactory(name="Seated Row")
@@ -124,7 +124,7 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_delete_routine_cascades_children_via_orphan(self, session):
-        """Deleting Routine should remove its RoutineExercise via ORM delete-orphan."""
+        """Arrange a routine with a child, delete the parent, and assert delete-orphan cascading removes dependents."""
         rx = RoutineExerciseFactory()
         session.add(rx)
         session.flush()

--- a/backend/tests/unit/test_model_routine.py
+++ b/backend/tests/unit/test_model_routine.py
@@ -15,7 +15,12 @@ class TestRoutineModel:
 
     @pytest.mark.unit
     def test_create_basic_routine(self, session):
-        """Arrange a routine via the factory, flush it, and assert ownership and timestamps exist."""
+        """Validate basic routine persistence.
+
+        Arrange with a factory routine linked to a user.
+        Act by flushing the session.
+        Assert ownership and timestamps populate.
+        """
         r = RoutineFactory()
         session.add(r)
         session.flush()
@@ -27,7 +32,12 @@ class TestRoutineModel:
 
     @pytest.mark.unit
     def test_name_required(self, session):
-        """Arrange a routine missing ``name``, attempt to flush, and verify the database rejects it."""
+        """Reject nameless routines.
+
+        Arrange a routine factory override without ``name``.
+        Act by flushing the session.
+        Assert the database raises an integrity error.
+        """
         u = UserFactory()
         session.add(u)
         session.flush()
@@ -38,7 +48,12 @@ class TestRoutineModel:
 
     @pytest.mark.unit
     def test_user_required(self, session):
-        """Arrange a routine without ``user_id``, flush, and ensure integrity enforcement triggers."""
+        """Enforce routine ownership.
+
+        Arrange a routine missing ``user_id``.
+        Act by flushing the session.
+        Assert integrity enforcement triggers.
+        """
         session.add(Routine(user_id=None, name="No owner"))
         with pytest.raises(IntegrityError):
             session.flush()
@@ -49,7 +64,12 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_create_basic_routine_exercise(self, session):
-        """Arrange a routine exercise via the factory, flush, and assert defaults and relationships are populated."""
+        """Validate routine exercise defaults.
+
+        Arrange with the factory and its linked routine and exercise.
+        Act by flushing the session.
+        Assert defaults, relationships, and timestamps populate.
+        """
         rx = RoutineExerciseFactory()
         session.add(rx)
         session.flush()
@@ -69,7 +89,12 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_order_unique_within_routine(self, session):
-        """Arrange two routine exercises sharing an order, flush, and expect a uniqueness violation."""
+        """Prevent duplicate routine exercise ordering.
+
+        Arrange two exercises sharing an order on one routine.
+        Act by flushing both to the database.
+        Assert the unique constraint raises an integrity error.
+        """
         r = RoutineFactory()
         e1 = ExerciseFactory(name="Bench Press")
         e2 = ExerciseFactory(name="Incline Bench")
@@ -86,7 +111,12 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_same_order_allowed_in_different_routines(self, session):
-        """Arrange exercises in separate routines with the same order, flush both, and confirm the constraint allows it."""
+        """Allow shared orders across routines.
+
+        Arrange exercises in separate routines with the same order.
+        Act by flushing both to the session.
+        Assert the constraint allows the inserts.
+        """
         r1 = RoutineFactory(name="A")
         r2 = RoutineFactory(name="B")
         ex = ExerciseFactory(name="Row")
@@ -102,7 +132,12 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_relationship_ordering_by_order(self, session):
-        """Arrange out-of-order inserts, access the relationship, and assert ordering follows the ``order`` column."""
+        """Ensure relationship ordering uses the column.
+
+        Arrange routine exercises inserted out of order.
+        Act by loading ``routine.exercises``.
+        Assert the sequence follows the ``order`` column.
+        """
         r = RoutineFactory()
         e1 = ExerciseFactory(name="Lat Pulldown")
         e2 = ExerciseFactory(name="Seated Row")
@@ -124,7 +159,12 @@ class TestRoutineExerciseModel:
 
     @pytest.mark.unit
     def test_delete_routine_cascades_children_via_orphan(self, session):
-        """Arrange a routine with a child, delete the parent, and assert delete-orphan cascading removes dependents."""
+        """Cascade routine deletions to children.
+
+        Arrange a routine with a dependent routine exercise.
+        Act by deleting the parent routine.
+        Assert delete-orphan cascading removes the child row.
+        """
         rx = RoutineExerciseFactory()
         session.add(rx)
         session.flush()

--- a/backend/tests/unit/test_model_user.py
+++ b/backend/tests/unit/test_model_user.py
@@ -13,7 +13,12 @@ class TestUserModel:
 
     @pytest.mark.unit
     def test_password_is_hashed_and_write_only(self, session):
-        """Arrange a user with a known password, flush, then assert hashing and access protections hold."""
+        """Ensure passwords hash and stay write only.
+
+        Arrange a user with a known raw password.
+        Act by flushing the instance.
+        Assert the hash differs and direct reads raise.
+        """
         u = UserFactory(email="alice@example.com", password="S3cret!!!")
         session.add(u)
         session.flush()
@@ -25,7 +30,12 @@ class TestUserModel:
 
     @pytest.mark.unit
     def test_verify_password(self, session):
-        """Arrange a user with a password, invoke ``verify_password``, and assert correct and incorrect inputs behave as expected."""
+        """Check password verification paths.
+
+        Arrange a user with a known password.
+        Act by calling ``verify_password`` with correct and incorrect inputs.
+        Assert success only for the matching password.
+        """
         u = UserFactory(email="bob@example.com", password="Correct#1")
         session.add(u)
         session.flush()
@@ -46,7 +56,12 @@ class TestUserModel:
 
     @pytest.mark.unit
     def test_timestamps_present(self, session):
-        """Arrange a user, flush it, and assert timestamp columns populate via the mixin defaults."""
+        """Populate timestamp columns via the mixin.
+
+        Arrange a user from the factory.
+        Act by flushing the session.
+        Assert created and updated timestamps are present.
+        """
         u = UserFactory()
         session.add(u)
         session.flush()

--- a/backend/tests/unit/test_model_user.py
+++ b/backend/tests/unit/test_model_user.py
@@ -1,4 +1,4 @@
-"""Unit tests for the `User` model."""
+"""Unit tests ensuring User model hashing, uniqueness, and timestamps."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ class TestUserModel:
 
     @pytest.mark.unit
     def test_password_is_hashed_and_write_only(self, session):
-        """Password setter should hash and disallow reading."""
+        """Arrange a user with a known password, flush, then assert hashing and access protections hold."""
         u = UserFactory(email="alice@example.com", password="S3cret!!!")
         session.add(u)
         session.flush()
@@ -25,7 +25,7 @@ class TestUserModel:
 
     @pytest.mark.unit
     def test_verify_password(self, session):
-        """verify_password should return True for correct password."""
+        """Arrange a user with a password, invoke ``verify_password``, and assert correct and incorrect inputs behave as expected."""
         u = UserFactory(email="bob@example.com", password="Correct#1")
         session.add(u)
         session.flush()
@@ -35,7 +35,7 @@ class TestUserModel:
 
     @pytest.mark.unit
     def test_email_unique(self, session):
-        """Unique constraint on email should be enforced."""
+        """Arrange two users sharing an email, flush the second, and expect an integrity error."""
         _ = UserFactory(email="dup@example.com")
         session.flush()
 
@@ -46,7 +46,7 @@ class TestUserModel:
 
     @pytest.mark.unit
     def test_timestamps_present(self, session):
-        """created_at/updated_at should be filled by mixin defaults."""
+        """Arrange a user, flush it, and assert timestamp columns populate via the mixin defaults."""
         u = UserFactory()
         session.add(u)
         session.flush()

--- a/backend/tests/unit/test_model_workout.py
+++ b/backend/tests/unit/test_model_workout.py
@@ -23,7 +23,7 @@ class TestWorkoutModel:
 
     @pytest.mark.unit
     def test_create_basic_workout(self, session):
-        """Factory should create a valid workout with user and timestamps."""
+        """Arrange a workout via the factory, flush, and assert ownership and timestamps populate."""
         w = WorkoutFactory()
         session.add(w)
         session.flush()
@@ -35,17 +35,17 @@ class TestWorkoutModel:
 
     @pytest.mark.unit
     def test_user_required(self, session):
-        """`user_id` is NOT NULL."""
+        """Arrange a workout without ``user_id``, flush, and expect an integrity failure."""
         session.add(Workout(user_id=None))
         with pytest.raises(IntegrityError):
             session.flush()
 
     @pytest.mark.unit
     def test_optional_routine_and_duration(self, session):
-        """routine_id and duration_min are optional."""
+        """Arrange a workout with optional fields, flush, and confirm nullable columns persist."""
         r = RoutineFactory()
         w = WorkoutFactory(duration_min=45)
-        # opcionalmente asignamos routine explícitamente:
+        # Optionally associate a specific routine for this scenario.
         w.routine = r
 
         session.add_all([r, w])
@@ -60,7 +60,7 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_create_basic_workout_exercise(self, session):
-        """Factory should create a valid workout exercise with defaults."""
+        """Arrange a workout exercise via the factory, flush, and assert relationships and timestamps populate."""
         we = WorkoutExerciseFactory()
         session.add(we)
         session.flush()
@@ -72,7 +72,7 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_order_unique_within_workout(self, session):
-        """(workout_id, order) must be unique within a workout."""
+        """Arrange two workout exercises sharing an order, flush, and expect the unique constraint to raise."""
         w = WorkoutFactory()
         ex1 = ExerciseFactory(name="Bench Press")
         ex2 = ExerciseFactory(name="Incline Bench")
@@ -90,7 +90,7 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_same_order_allowed_in_different_workouts(self, session):
-        """Same `order` is allowed across different workouts."""
+        """Arrange exercises in different workouts with matching order, flush both, and confirm no error occurs."""
         w1 = WorkoutFactory()
         w2 = WorkoutFactory()
         ex = ExerciseFactory(name="Row")
@@ -104,7 +104,7 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_relationship_ordering_by_order(self, session):
-        """Workout.exercises should be ordered by `order` as per relationship."""
+        """Arrange out-of-order inserts, access ``workout.exercises``, and verify results sorted by ``order``."""
         w = WorkoutFactory()
         ex1 = ExerciseFactory(name="Lat Pulldown")
         ex2 = ExerciseFactory(name="Seated Row")
@@ -124,7 +124,7 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_delete_workout_cascades_children(self, session):
-        """Deleting Workout should remove its WorkoutExercises and WorkoutSets."""
+        """Arrange a workout with nested children, delete the parent, and assert cascading removes all rows."""
         ws = WorkoutSetFactory()  # creates workout, workout_exercise, and set
         w = ws.workout_exercise.workout
         we = ws.workout_exercise
@@ -147,7 +147,7 @@ class TestWorkoutSetModel:
 
     @pytest.mark.unit
     def test_create_basic_set(self, session):
-        """Factory should create a valid set with defaults."""
+        """Arrange a workout set via the factory, flush, and assert defaults and relationships remain intact."""
         s = WorkoutSetFactory()
         session.add(s)
         session.flush()
@@ -162,7 +162,7 @@ class TestWorkoutSetModel:
 
     @pytest.mark.unit
     def test_set_index_unique_within_workout_exercise(self, session):
-        """(workout_exercise_id, set_index) must be unique."""
+        """Arrange duplicate set indexes for one exercise, flush, and expect a uniqueness violation."""
         we = WorkoutExerciseFactory()
         session.add(we)
         session.flush()
@@ -176,7 +176,7 @@ class TestWorkoutSetModel:
 
     @pytest.mark.unit
     def test_nullable_metrics_fields(self, session):
-        """weight_kg, rpe, rir, time_sec can be NULL."""
+        """Arrange a workout set with all optional metrics null, flush, and confirm retrieval preserves ``None`` values."""
         we = WorkoutExerciseFactory()
         s = WorkoutSet(
             workout_exercise_id=we.id,

--- a/backend/tests/unit/test_model_workout.py
+++ b/backend/tests/unit/test_model_workout.py
@@ -23,7 +23,12 @@ class TestWorkoutModel:
 
     @pytest.mark.unit
     def test_create_basic_workout(self, session):
-        """Arrange a workout via the factory, flush, and assert ownership and timestamps populate."""
+        """Validate workout creation defaults.
+
+        Arrange a workout from the factory tied to a user.
+        Act by flushing the session.
+        Assert ownership, date, and timestamps populate.
+        """
         w = WorkoutFactory()
         session.add(w)
         session.flush()
@@ -60,7 +65,12 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_create_basic_workout_exercise(self, session):
-        """Arrange a workout exercise via the factory, flush, and assert relationships and timestamps populate."""
+        """Validate workout exercise creation.
+
+        Arrange with the factory to include workout and exercise relations.
+        Act by flushing the session.
+        Assert relationship links and timestamps populate.
+        """
         we = WorkoutExerciseFactory()
         session.add(we)
         session.flush()
@@ -72,7 +82,12 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_order_unique_within_workout(self, session):
-        """Arrange two workout exercises sharing an order, flush, and expect the unique constraint to raise."""
+        """Reject duplicate workout exercise ordering.
+
+        Arrange two exercises with the same ``order`` on one workout.
+        Act by flushing both records.
+        Assert the unique constraint raises an integrity error.
+        """
         w = WorkoutFactory()
         ex1 = ExerciseFactory(name="Bench Press")
         ex2 = ExerciseFactory(name="Incline Bench")
@@ -90,7 +105,12 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_same_order_allowed_in_different_workouts(self, session):
-        """Arrange exercises in different workouts with matching order, flush both, and confirm no error occurs."""
+        """Permit matching orders across workouts.
+
+        Arrange exercises mapped to different workouts with order ``1``.
+        Act by flushing both inserts.
+        Assert no integrity error occurs.
+        """
         w1 = WorkoutFactory()
         w2 = WorkoutFactory()
         ex = ExerciseFactory(name="Row")
@@ -104,7 +124,12 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_relationship_ordering_by_order(self, session):
-        """Arrange out-of-order inserts, access ``workout.exercises``, and verify results sorted by ``order``."""
+        """Order workout exercises by column value.
+
+        Arrange inserts out of order.
+        Act by accessing ``workout.exercises``.
+        Assert the relationship sorts by the ``order`` column.
+        """
         w = WorkoutFactory()
         ex1 = ExerciseFactory(name="Lat Pulldown")
         ex2 = ExerciseFactory(name="Seated Row")
@@ -124,7 +149,12 @@ class TestWorkoutExerciseModel:
 
     @pytest.mark.unit
     def test_delete_workout_cascades_children(self, session):
-        """Arrange a workout with nested children, delete the parent, and assert cascading removes all rows."""
+        """Cascade workout deletions to dependents.
+
+        Arrange a workout with generated nested children.
+        Act by deleting the workout parent.
+        Assert cascades remove exercises and sets.
+        """
         ws = WorkoutSetFactory()  # creates workout, workout_exercise, and set
         w = ws.workout_exercise.workout
         we = ws.workout_exercise
@@ -147,7 +177,12 @@ class TestWorkoutSetModel:
 
     @pytest.mark.unit
     def test_create_basic_set(self, session):
-        """Arrange a workout set via the factory, flush, and assert defaults and relationships remain intact."""
+        """Validate workout set creation.
+
+        Arrange a set from the factory tied to a workout exercise.
+        Act by flushing the session.
+        Assert defaults, relationships, and timestamps remain intact.
+        """
         s = WorkoutSetFactory()
         session.add(s)
         session.flush()
@@ -162,7 +197,12 @@ class TestWorkoutSetModel:
 
     @pytest.mark.unit
     def test_set_index_unique_within_workout_exercise(self, session):
-        """Arrange duplicate set indexes for one exercise, flush, and expect a uniqueness violation."""
+        """Reject duplicate set indexes within an exercise.
+
+        Arrange two sets on the same workout exercise sharing ``set_index``.
+        Act by flushing both rows.
+        Assert the uniqueness constraint raises an error.
+        """
         we = WorkoutExerciseFactory()
         session.add(we)
         session.flush()
@@ -176,7 +216,12 @@ class TestWorkoutSetModel:
 
     @pytest.mark.unit
     def test_nullable_metrics_fields(self, session):
-        """Arrange a workout set with all optional metrics null, flush, and confirm retrieval preserves ``None`` values."""
+        """Preserve optional workout set metrics.
+
+        Arrange a set with all nullable metrics set to ``None``.
+        Act by flushing and reloading the row.
+        Assert retrieval keeps each metric at ``None``.
+        """
         we = WorkoutExerciseFactory()
         s = WorkoutSet(
             workout_exercise_id=we.id,


### PR DESCRIPTION
## Summary
- document the Flask application factory, core utilities, and API blueprints with reStructuredText-compliant docstrings
- describe ORM models, schemas, and extensions to clarify relationships, configuration, and lifecycle behavior
- expand pytest fixtures, helpers, and model tests with AAA-style docstrings for clarity during maintenance

## Testing
- not run (docstring-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc4ec942048325adb64da2499cbe58