### PR TITLE
Refine gitignore coverage for FitnessTrack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,104 @@
 # Python
 __pycache__/
-*.pyc
-.venv/
-.env
+*.py[cod]
+*$py.class
+*.pyd
+*.pyo
+*.so
 
-# Node
-node_modules/
+# Python packaging
+build/
 dist/
+wheelhouse/
+*.egg
+*.egg-info/
+.eggs/
+pip-wheel-metadata/
+MANIFEST
 
-# Vite
-*.local
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+env.bak/
+.env
+.env.*
+!.env.example
+!.env.*.example
+.pyenv
+.python-version
 
-# OS
-.DS_Store
-
-# Docker
-*.log
-
+# Python tooling & reports
 .mypy_cache/
-.ruff_cache/
 .pytest_cache/
-
-.coverage
+.ruff_cache/
+.tox/
+.nox/
+.hypothesis/
+.coverage*
 coverage.xml
+htmlcov/
+
+# Node / JavaScript
+node_modules/
+**/node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+.pnp*/
+.pnp.js
+.eslintcache
+.stylelintcache
+*.tsbuildinfo
+
+# Frontend build outputs
+frontend/build/
+frontend/dist/
+.next/
+.nuxt/
+out/
+.svelte-kit/
+.storybook-static/
+.turbo/
+.parcel-cache/
+.cache/
+coverage/
+
+# Docker / Containers
+.docker/
+docker-compose.override.yml
+docker-compose.override.yaml
+docker-compose.local.yml
+docker-compose.local.yaml
+docker-data/
+docker-volumes/
+*.pid
+
+# Logs & temporary files
+*.log
+*.out
+*.tmp
+*.swp
+*.swo
+*.orig
+
+# IDE / Editor
+.idea/
+.vscode/
+*.code-workspace
+.vs/
+*.sublime-project
+*.sublime-workspace
+.history/
+*.iml
+
+# OS / System
+**/.DS_Store
+Icon?
+._*
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,13 +1,12 @@
-# Python
-__pycache__/
-*.pyc
-.venv/
-.env
+# Flask instance & local databases
 instance/
+*.db
+*.db-journal
+*.sqlite
+*.sqlite3
 
-# coverage / pytest
-.coverage
-coverage.xml
-htmlcov/
-.pytest_cache/
-__pycache__/
+# Local environment overrides
+.env
+.env.*
+!.env.example
+!.env.*.example


### PR DESCRIPTION
## Summary
- expand the root `.gitignore` to cover Python, Node/React, Docker, tooling caches, editors, and system artifacts
- add a backend-specific `.gitignore` to hide Flask instance databases and local environment overrides

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc61f800f883259e565f3ff74007ca