### PR TITLE
docs: add link to backend data model documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ A full-stack fitness workout tracking application built to consolidate the skill
 └── README.md
 ```
 
+## Data Model Documentation
+
+Review the [backend data model reference](backend/app/models/README.md) for a complete overview of every domain entity. The document includes detailed field descriptions and an accompanying Mermaid diagram that visualizes the relationships across the schema.
+
 ## Installation
 
 1. **Clone the repository**


### PR DESCRIPTION
## Summary
- add a README section highlighting the backend data model reference
- mention that the model documentation includes detailed descriptions and a Mermaid diagram

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df199f6b708325b7d7a0f23eb1351d