### PR TITLE
Type subject pseudonym column as UUID

### DIFF
--- a/backend/app/models/subject.py
+++ b/backend/app/models/subject.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date
 from enum import Enum
 from typing import TYPE_CHECKING
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from sqlalchemy import (
     Date,
@@ -19,7 +19,7 @@ from sqlalchemy import (
 from sqlalchemy import (
     Enum as SAEnum,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.extensions import db
@@ -54,7 +54,7 @@ class Subject(PKMixin, ReprMixin, TimestampMixin, db.Model):
     user_id: Mapped[int | None] = mapped_column(
         ForeignKey("users.id", ondelete="SET NULL"), nullable=True, unique=True
     )
-    pseudonym: Mapped[str] = mapped_column(UUID(as_uuid=True), nullable=False, default=uuid4)
+    pseudonym: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False, default=uuid4)
 
     user = relationship(
         "User",


### PR DESCRIPTION
## Summary
- import the standard library UUID type in the subject model and alias the PostgreSQL UUID column type
- annotate the subject pseudonym column as `Mapped[UUID]` for clearer typing

## Testing
- mypy --ignore-missing-imports backend/app/models/subject.py *(fails: existing errors in unrelated modules such as `app.core.errors` and `app.core.proxy`)*

------
https://chatgpt.com/codex/tasks/task_e_68df2c3bb8c48325b17bce918849d19c