### PR TITLE
Ensure Numeric columns emit floats

### DIFF
--- a/backend/app/models/exercise_log.py
+++ b/backend/app/models/exercise_log.py
@@ -64,10 +64,10 @@ class ExerciseSetLog(PKMixin, TimestampMixin, ReprMixin, db.Model):
     to_failure: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
     # --- Actuals (performed) ---
-    actual_weight_kg: Mapped[float | None] = mapped_column(Numeric(6, 2))
+    actual_weight_kg: Mapped[float | None] = mapped_column(Numeric(6, 2, asdecimal=False))
     actual_reps: Mapped[int | None] = mapped_column(Integer)
     actual_rir: Mapped[int | None] = mapped_column(Integer)
-    actual_rpe: Mapped[float | None] = mapped_column(Numeric(3, 1))
+    actual_rpe: Mapped[float | None] = mapped_column(Numeric(3, 1, asdecimal=False))
     actual_tempo: Mapped[str | None] = mapped_column(String(15))
     actual_rest_s: Mapped[int | None] = mapped_column(Integer)
 

--- a/backend/app/models/routine.py
+++ b/backend/app/models/routine.py
@@ -149,10 +149,10 @@ class RoutineExerciseSet(PKMixin, TimestampMixin, ReprMixin, db.Model):
     is_warmup: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
     to_failure: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
-    target_weight_kg: Mapped[float | None] = mapped_column(Numeric(6, 2))
+    target_weight_kg: Mapped[float | None] = mapped_column(Numeric(6, 2, asdecimal=False))
     target_reps: Mapped[int | None] = mapped_column(Integer)
     target_rir: Mapped[int | None] = mapped_column(Integer)
-    target_rpe: Mapped[float | None] = mapped_column(Numeric(3, 1))
+    target_rpe: Mapped[float | None] = mapped_column(Numeric(3, 1, asdecimal=False))
     target_tempo: Mapped[str | None] = mapped_column(String(15))
     target_rest_s: Mapped[int | None] = mapped_column(Integer)
 

--- a/backend/app/models/subject.py
+++ b/backend/app/models/subject.py
@@ -240,8 +240,12 @@ class SubjectBodyMetrics(PKMixin, ReprMixin, TimestampMixin, db.Model):
     )
     measured_on: Mapped[date] = mapped_column(Date, nullable=False)
 
-    weight_kg: Mapped[float | None] = mapped_column(Numeric(5, 2), nullable=True)
-    bodyfat_pct: Mapped[float | None] = mapped_column(Numeric(4, 1), nullable=True)
+    weight_kg: Mapped[float | None] = mapped_column(
+        Numeric(5, 2, asdecimal=False), nullable=True
+    )
+    bodyfat_pct: Mapped[float | None] = mapped_column(
+        Numeric(4, 1, asdecimal=False), nullable=True
+    )
     resting_hr: Mapped[int | None] = mapped_column(Integer, nullable=True)
     notes: Mapped[str | None] = mapped_column(db.Text, nullable=True)
 

--- a/backend/app/models/workout.py
+++ b/backend/app/models/workout.py
@@ -58,7 +58,7 @@ class WorkoutSession(PKMixin, TimestampMixin, ReprMixin, db.Model):
 
     location: Mapped[str | None] = mapped_column(String(120))
     perceived_fatigue: Mapped[int | None] = mapped_column(Integer)
-    bodyweight_kg: Mapped[float | None] = mapped_column(Numeric(5, 2))
+    bodyweight_kg: Mapped[float | None] = mapped_column(Numeric(5, 2, asdecimal=False))
     notes: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (


### PR DESCRIPTION
## Summary
- ensure Numeric-mapped float fields in routine, exercise log, subject, and workout models set `asdecimal=False`

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_68df300e634483259a52fae24b104e60