### PR TITLE
Add REST API blueprint skeleton and OpenAPI spec

### DIFF
--- a/backend/app/api/README.md
+++ b/backend/app/api/README.md
@@ -1,0 +1,126 @@
+# API Endpoint Map
+
+The API follows a resource-oriented style under the `/api/v1` prefix. All
+collection endpoints support `page`, `limit`, `sort`, and simple equality
+filters. List responses use the envelope
+`{"items": [...], "page": 1, "limit": 50, "total": 123}`. Partial updates
+require `If-Match` with entity ETags derived from `updated_at` and primary keys.
+
+## System
+
+| Resource | URI | Notes |
+| --- | --- | --- |
+| Health | `GET /api/v1/health` | Returns process, DB connectivity, and latency telemetry. |
+
+## Users
+
+| Resource | URI | Filters / Query params | Relationships |
+| --- | --- | --- | --- |
+| Users collection | `GET /api/v1/users` | `email`, `username`, `sort` (`id`, `created_at`, `username`) | Links to a single `Subject` (if any). |
+| User detail | `GET /api/v1/users/{user_id}` | — | Returns subject linkage metadata. |
+| Create user | `POST /api/v1/users` | Requires `Idempotency-Key` for safe retries. | Creates optional subject association via `subject_id`. |
+| Update user | `PATCH /api/v1/users/{user_id}` | Requires `If-Match`. | Allows updating profile-safe fields (`username`, `full_name`, password reset). |
+| Delete user | `DELETE /api/v1/users/{user_id}` | Hard delete (subject anonymization handled separately). | Cascade severed through FK rules. |
+
+## Subjects & Profiles
+
+| Resource | URI | Filters / Query params | Relationships |
+| --- | --- | --- | --- |
+| Subjects | `GET /api/v1/subjects` | `user_id`, `pseudonym`, `sort` (`id`, `created_at`) | Owners of routines, cycles, workouts, logs. |
+| Subject detail | `GET /api/v1/subjects/{subject_id}` | — | Includes link to profile route. |
+| Create subject | `POST /api/v1/subjects` | Idempotent via header. | Optional `user_id` link. |
+| Update subject | `PATCH /api/v1/subjects/{subject_id}` | Requires `If-Match`. | Supports unlinking user for GDPR deletion. |
+| Delete subject | `DELETE /api/v1/subjects/{subject_id}` | Hard delete (domain cascade). | Removes dependent records via FK `ON DELETE CASCADE`. |
+| Subject profile | `GET /api/v1/subjects/{subject_id}/profile` | — | 1:1; returns 404 if missing. |
+| Replace profile | `PUT /api/v1/subjects/{subject_id}/profile` | Requires `If-Match` when existing. | Creates or replaces the profile document. |
+| Body metrics collection | `GET /api/v1/subjects/{subject_id}/body-metrics` | `measured_on`, `sort` (`measured_on desc` default). | Time-series of indirect PII. |
+| Body metric detail | `GET /api/v1/subjects/{subject_id}/body-metrics/{metric_id}` | — | Scoped to owner subject. |
+| Create body metric | `POST /api/v1/subjects/{subject_id}/body-metrics` | Idempotent via header. | Requires `measured_on`. |
+| Update body metric | `PATCH /api/v1/subjects/{subject_id}/body-metrics/{metric_id}` | Requires `If-Match`. | Partial merge, e.g., adjusting weight. |
+| Delete body metric | `DELETE /api/v1/subjects/{subject_id}/body-metrics/{metric_id}` | Hard delete. | Removes a single measurement. |
+
+## Exercises & Taxonomy
+
+| Resource | URI | Filters / Query params | Relationships |
+| --- | --- | --- | --- |
+| Exercises | `GET /api/v1/exercises` | `name`, `primary_muscle`, `equipment`, `is_active`, `sort` (`name`, `created_at`, `difficulty`) | Related to routine templates and performed logs. |
+| Exercise detail | `GET /api/v1/exercises/{exercise_id}` | — | Includes alias/tag links. |
+| Create exercise | `POST /api/v1/exercises` | Requires `Idempotency-Key`. | Accepts secondary muscles, aliases, tags arrays. |
+| Update exercise | `PATCH /api/v1/exercises/{exercise_id}` | Requires `If-Match`. | Partial update of metadata and active status. |
+| Delete exercise | `DELETE /api/v1/exercises/{exercise_id}` | Soft delete simulated by toggling `is_active`. |
+| Reference enums | `GET /api/v1/exercises/meta/{enum_name}` | — | Exposes enumerations (`muscle_groups`, `equipment`, `movement_patterns`, `levels`, `force_vectors`, `mechanics`). |
+
+## Routines & Templates
+
+| Resource | URI | Filters / Query params | Relationships |
+| --- | --- | --- | --- |
+| Routines | `GET /api/v1/routines` | `owner_subject_id`, `is_public`, `name`, `sort` (`created_at`, `name`) | Owns `routine_days`, `subject_routines`, and `cycles`. |
+| Routine detail | `GET /api/v1/routines/{routine_id}` | — | Includes summary counts. |
+| Create routine | `POST /api/v1/routines` | Requires `Idempotency-Key`. | Body accepts initial sharing flag. |
+| Update routine | `PATCH /api/v1/routines/{routine_id}` | Requires `If-Match`. | Adjust metadata and activation state. |
+| Delete routine | `DELETE /api/v1/routines/{routine_id}` | Hard delete; cascades to template hierarchy. |
+| Routine days | `GET /api/v1/routines/{routine_id}/days` | `sort` (`day_index`). | Child-only resource. |
+| Routine day detail | `GET /api/v1/routines/{routine_id}/days/{day_id}` | — | Contains exercises and notes. |
+| Create/Update/Delete routine day | `POST`, `PATCH`, `DELETE /api/v1/routines/{routine_id}/days` | Idempotency for create; `If-Match` for updates. | Maintains ordering via `day_index`. |
+| Routine day exercises | `GET /api/v1/routines/{routine_id}/days/{day_id}/exercises` | `sort` (`position`). | Sequence of exercises referencing catalog. |
+| Routine exercise sets | `GET /api/v1/routines/{routine_id}/days/{day_id}/exercises/{exercise_id}/sets` | — | Planned targets per set. |
+
+## Subject Routine Library
+
+| Resource | URI | Filters / Query params | Relationships |
+| --- | --- | --- | --- |
+| Subject routine links | `GET /api/v1/subject-routines` | `subject_id`, `routine_id`, `is_active` | Connects subjects to shared/public routines. |
+| Create link | `POST /api/v1/subject-routines` | Requires `Idempotency-Key`. | Adds saved routine reference. |
+| Delete link | `DELETE /api/v1/subject-routines/{link_id}` | — | Removes saved routine. |
+
+## Cycles & Execution
+
+| Resource | URI | Filters / Query params | Relationships |
+| --- | --- | --- | --- |
+| Cycles | `GET /api/v1/cycles` | `subject_id`, `routine_id`, `cycle_number`, `sort` (`started_on`, `created_at`) | Binds template to execution window. |
+| Cycle detail | `GET /api/v1/cycles/{cycle_id}` | — | Includes related session count summary. |
+| Create cycle | `POST /api/v1/cycles` | Requires `Idempotency-Key`. | Enforces `(subject_id, routine_id, cycle_number)` uniqueness. |
+| Update cycle | `PATCH /api/v1/cycles/{cycle_id}` | Requires `If-Match`. | Adjust dates, notes. |
+| Delete cycle | `DELETE /api/v1/cycles/{cycle_id}` | Hard delete; dependent sessions set `NULL`. |
+
+## Workout Sessions & Logs
+
+| Resource | URI | Filters / Query params | Relationships |
+| --- | --- | --- | --- |
+| Workout sessions | `GET /api/v1/workouts/sessions` | `subject_id`, `status`, `from`, `to`, `sort` (`workout_date`, `created_at`) | Optionally linked to `routine_day` and `cycle`. |
+| Session detail | `GET /api/v1/workouts/sessions/{session_id}` | — | Includes basic relation metadata. |
+| Create session | `POST /api/v1/workouts/sessions` | Requires `Idempotency-Key`. | Validates subject/cycle pairing. |
+| Update session | `PATCH /api/v1/workouts/sessions/{session_id}` | Requires `If-Match`. | Partial update for status, fatigue metrics. |
+| Delete session | `DELETE /api/v1/workouts/sessions/{session_id}` | Hard delete. |
+| Exercise set logs | `GET /api/v1/workouts/set-logs` | `subject_id`, `exercise_id`, `session_id`, `from`, `to`, `sort` (`performed_at`) | Links actual sets to planned sets. |
+| Set log detail | `GET /api/v1/workouts/set-logs/{log_id}` | — | Returns session/planned linkage. |
+| Create set log | `POST /api/v1/workouts/set-logs` | Requires `Idempotency-Key`. | Enforces subject consistency with linked session. |
+| Update set log | `PATCH /api/v1/workouts/set-logs/{log_id}` | Requires `If-Match`. | Partial adjustments for actual values. |
+| Delete set log | `DELETE /api/v1/workouts/set-logs/{log_id}` | Hard delete. |
+
+## Reference Data
+
+| Resource | URI | Notes |
+| --- | --- | --- |
+| Enumerations | `GET /api/v1/reference/{name}` | Mirrors database enums when not tied to exercises (e.g., `sex`, `workout_status`). |
+
+## Rationale
+
+- **Resource boundaries** mirror SQLAlchemy models, promoting clarity between
+  template data (`routines`, `routine_days`, `routine_day_exercises`,
+  `routine_exercise_sets`) and execution data (`cycles`, `workout_sessions`,
+  `exercise_set_logs`). Hierarchical URIs are only used for entities that cannot
+  exist independently (`routine_days`, subject profiles, body metrics),
+  preserving top-level access for shareable resources (`routines`, `cycles`).
+- **Versioned prefix** `/api/v1` isolates the contract for evolution. Future
+  iterations can register additional blueprints without breaking the factory.
+- **Pagination and sorting** are consistent across collections to keep client
+  ergonomics predictable and to guard against unbounded queries.
+- **Problem Details** (RFC 7807 / RFC 9457) unify error payloads, ensuring
+  machine-readable `type`, `code`, and `errors` arrays when validation fails.
+- **Concurrency safety** leans on ETags derived from `(id, updated_at)` for
+  optimistic locking via `If-Match`, while `Idempotency-Key` headers prevent
+  duplicate writes in retry scenarios.
+- **Security** stubs enforce bearer-token presence on mutating endpoints and
+  leave clear TODO markers for scope/role checks, aligning with future JWT
+  adoption.

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,66 +1,33 @@
-"""API blueprint package aggregating versioned endpoints."""
+"""API blueprint wiring and helper registration."""
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from flask import Flask
 
-from flask import Blueprint, Flask
+from .errors import register_problem_handlers
+from .v1 import api_v1
 
-
-def register_blueprint_group(
-    app: Flask,
-    *,
-    base_prefix: str,
-    entries: Iterable[tuple[Blueprint, str]],
-) -> None:
-    """Register related blueprints beneath a common prefix.
-
-    Parameters
-    ----------
-    app: flask.Flask
-        Application instance receiving the blueprints.
-    base_prefix: str
-        Prefix applied to all entries, typically the API version segment such
-        as ``"/api/v1"``.
-    entries: Iterable[tuple[flask.Blueprint, str]]
-        Iterable of ``(blueprint, relative_prefix)`` pairs where
-        ``relative_prefix`` is appended to ``base_prefix``.
-
-    Notes
-    -----
-    Empty relative prefixes are supported, allowing a blueprint to mount at the
-    version root while others extend it with additional path segments.
-    """
-    for bp, rel_prefix in entries:
-        # Normalize slashes safely
-        full_prefix = "/".join(
-            seg for seg in [base_prefix.rstrip("/"), rel_prefix.strip("/")] if seg
-        )
-        full_prefix = "/" + full_prefix if not full_prefix.startswith("/") else full_prefix
-        app.register_blueprint(bp, url_prefix=full_prefix)
+__all__ = ["init_app", "api_v1"]
 
 
 def init_app(app: Flask) -> None:
-    """Register the available API versions on the Flask app.
+    """Attach versioned API blueprints to the Flask application.
 
     Parameters
     ----------
-    app: flask.Flask
-        Application instance to wire with blueprints.
+    app:
+        Flask application created via :func:`app.factory.create_app`.
 
     Notes
     -----
-    The base prefix defaults to ``"/api"`` but can be overridden via the
-    ``API_BASE_PREFIX`` configuration key.
+    - The API is versioned under ``/api/v1`` following a URI-based strategy.
+    - RFC 7807 problem handlers are registered on the blueprint before the
+      blueprint is attached to the app to guarantee consistent error payloads.
+    - Future versions can be registered by extending this module without
+      changing the application factory signature.
     """
-    api_base = app.config.get("API_BASE_PREFIX", "/api")
 
-    # v1
-    from app.api.v1 import API_VERSION as V1
-    from app.api.v1 import REGISTRY as V1_REGISTRY
-
-    register_blueprint_group(app, base_prefix=f"{api_base}/{V1}", entries=V1_REGISTRY)
-
-    # Future:
-    # from app.api.v2 import API_VERSION as V2, REGISTRY as V2_REGISTRY
-    # register_blueprint_group(app, base_prefix=f"{api_base}/{V2}", entries=V2_REGISTRY)
+    if not getattr(api_v1, "_problem_handlers_registered", False):
+        register_problem_handlers(api_v1)
+        setattr(api_v1, "_problem_handlers_registered", True)
+    app.register_blueprint(api_v1)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,268 @@
+"""Shared API dependencies: auth stubs, pagination, and request utilities."""
+
+from __future__ import annotations
+
+import functools
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping, TypeVar
+
+from flask import Response, current_app, g, jsonify, request
+from sqlalchemy.orm import Query
+
+from app.core.extensions import db
+
+from .errors import problem
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+@dataclass(slots=True)
+class Pagination:
+    """Parsed pagination parameters extracted from the query string."""
+
+    page: int
+    limit: int
+    sort: list[str]
+
+
+def parse_pagination(default_limit: int = 50, max_limit: int = 100) -> Pagination:
+    """Parse ``page``, ``limit``, and ``sort`` query parameters.
+
+    :param default_limit: Default number of records per page when ``limit`` is omitted.
+    :type default_limit: int
+    :param max_limit: Upper bound to guard against unbounded result sets.
+    :type max_limit: int
+    :returns: Parsed pagination container ready for query helpers.
+    :rtype: Pagination
+    """
+
+    page = request.args.get("page", type=int) or 1
+    limit = request.args.get("limit", type=int) or default_limit
+    if limit > max_limit:
+        limit = max_limit
+    sort_raw = request.args.get("sort", "")
+    sort = [segment.strip() for segment in sort_raw.split(",") if segment.strip()]
+    return Pagination(page=page if page > 0 else 1, limit=limit if limit > 0 else default_limit, sort=sort)
+
+
+def apply_sorting(query: Query, sort_fields: Mapping[str, Any], sort_params: Iterable[str]) -> Query:
+    """Apply client-provided sorting to a SQLAlchemy query.
+
+    :param query: Base SQLAlchemy query object.
+    :type query: sqlalchemy.orm.Query
+    :param sort_fields: Mapping between external sort keys and SQLAlchemy columns/expressions.
+    :type sort_fields: collections.abc.Mapping
+    :param sort_params: Sequence of raw sort tokens (``field`` or ``-field`` for descending).
+    :type sort_params: collections.abc.Iterable[str]
+    :returns: Query with ordering clauses applied.
+    :rtype: sqlalchemy.orm.Query
+    """
+
+    order_clauses: list[Any] = []
+    for raw in sort_params:
+        direction = raw.startswith("-")
+        key = raw[1:] if direction else raw
+        column = sort_fields.get(key)
+        if column is None:
+            continue
+        order_clauses.append(column.desc() if direction else column.asc())
+    if order_clauses:
+        query = query.order_by(*order_clauses)
+    return query
+
+
+def paginate_query(query: Query, pagination: Pagination) -> tuple[list[Any], int]:
+    """Apply pagination to a SQLAlchemy query returning items and total count.
+
+    :param query: SQLAlchemy query to paginate.
+    :type query: sqlalchemy.orm.Query
+    :param pagination: Pagination parameters derived from the request.
+    :type pagination: Pagination
+    :returns: Tuple with ``(items, total_count)``.
+    :rtype: tuple[list[Any], int]
+    """
+
+    total = query.order_by(None).count()
+    items = (
+        query.offset((pagination.page - 1) * pagination.limit)
+        .limit(pagination.limit)
+        .all()
+    )
+    return items, total
+
+
+def get_session():
+    """Return the SQLAlchemy session bound to the Flask app.
+
+    :returns: Active SQLAlchemy session.
+    :rtype: sqlalchemy.orm.Session
+    """
+
+    return db.session
+
+
+def require_auth(func: F) -> F:
+    """Decorator stub enforcing presence of an ``Authorization`` header.
+
+    The decorator ensures that mutating endpoints receive a bearer token. Full
+    JWT validation is intentionally deferred; the handler simply captures the
+    token for downstream TODO hooks.
+
+    :param func: View function to decorate.
+    :type func: collections.abc.Callable
+    :returns: Wrapped function that performs header validation.
+    :rtype: collections.abc.Callable
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.lower().startswith("bearer "):
+            return problem(
+                status=401,
+                title="Unauthorized",
+                detail="Bearer token required for this endpoint.",
+                code="unauthorized",
+            )
+        g.current_token = auth_header.split(" ", 1)[1]
+        return func(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
+def require_scope(required: str) -> Callable[[F], F]:
+    """Decorator stub asserting a scope is present in the bearer token.
+
+    Until real JWT parsing is wired, the decorator simply logs the desired
+    scope and allows execution to continue.
+
+    :param required: Scope name expected on the access token.
+    :type required: str
+    :returns: Decorator for view functions.
+    :rtype: collections.abc.Callable
+    """
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):
+            token = getattr(g, "current_token", None)
+            current_app.logger.debug("Scope check placeholder", extra={"required": required, "token": token})
+            # TODO: Parse JWT claims and validate scopes/roles.
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def idempotency_cache() -> dict[str, Any]:
+    """Return the application-level in-memory idempotency cache.
+
+    The cache is a best-effort, process-local dictionary stored under the
+    ``idempotency_cache`` key in ``app.extensions``. Production deployments
+    should replace this with a persistent store (e.g., Redis) to survive
+    restarts and multi-worker setups.
+
+    :returns: Mutable dictionary storing cached responses.
+    :rtype: dict[str, Any]
+    """
+
+    store = current_app.extensions.setdefault("idempotency_cache", {})
+    return store  # type: ignore[return-value]
+
+
+def enforce_idempotency(key: str | None) -> tuple[bool, dict[str, Any] | None]:
+    """Ensure an ``Idempotency-Key`` is respected for unsafe requests.
+
+    Parameters
+    ----------
+    key:
+        Value from the ``Idempotency-Key`` header. ``None`` disables checks.
+
+    Returns
+    -------
+    tuple
+        ``(is_replay, cached_payload)``. When ``is_replay`` is ``True`` a
+        previous response blueprint is returned as ``cached_payload``. Callers
+        should short-circuit and convert it into a Flask response immediately.
+    """
+
+    if not key:
+        return False, None
+    cache = idempotency_cache()
+    cached = cache.get(key)
+    if cached is not None:
+        return True, cached
+    return False, None
+
+
+def store_idempotent_response(key: str | None, payload: dict[str, Any]) -> None:
+    """Persist a response blueprint for future ``Idempotency-Key`` replays.
+
+    :param key: Idempotency key value from the client.
+    :type key: str | None
+    :param payload: Serialized response blueprint to reuse.
+    :type payload: dict[str, Any]
+    """
+
+    if not key:
+        return
+    cache = idempotency_cache()
+    cache[key] = payload
+
+
+def build_cached_response(payload: dict[str, Any]) -> Response:
+    """Instantiate a Flask response from cached idempotency metadata.
+
+    :param payload: Cached response blueprint returned by :func:`enforce_idempotency`.
+    :type payload: dict[str, Any]
+    :returns: Rehydrated Flask response.
+    :rtype: flask.Response
+    """
+
+    response = json_response(payload.get("body", {}), status=payload.get("status", 200))
+    for header, value in payload.get("headers", {}).items():
+        response.headers[header] = value
+    return response
+
+
+
+
+def json_response(payload: Any, *, status: int = 200) -> Response:
+    """Serialize payload into a Flask JSON response with consistent mimetype.
+
+    :param payload: Serializable payload.
+    :type payload: Any
+    :param status: HTTP status code for the response.
+    :type status: int
+    :returns: Flask response with ``application/json`` MIME type.
+    :rtype: flask.Response
+    """
+
+    response = jsonify(payload)
+    response.status_code = status
+    return response
+
+
+def timing(func: F) -> F:
+    """Simple decorator measuring handler execution time for structured logs.
+
+    :param func: View function to wrap.
+    :type func: collections.abc.Callable
+    :returns: Wrapped function emitting debug timing logs.
+    :rtype: collections.abc.Callable
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        start = time.perf_counter()
+        try:
+            return func(*args, **kwargs)
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            current_app.logger.debug(
+                "api.request.elapsed", extra={"endpoint": request.endpoint, "elapsed_ms": round(elapsed_ms, 2)}
+            )
+
+    return wrapper  # type: ignore[return-value]

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -1,0 +1,106 @@
+"""RFC 7807 / RFC 9457 problem helpers for the API layer."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+
+from flask import Blueprint, Response, current_app, jsonify, request
+from marshmallow import ValidationError
+from werkzeug.exceptions import HTTPException
+
+
+def problem(
+    *,
+    status: int,
+    title: str | None = None,
+    detail: str | None = None,
+    type: str = "about:blank",
+    instance: str | None = None,
+    code: str | None = None,
+    errors: list[dict[str, Any]] | dict[str, Any] | None = None,
+) -> Response:
+    """Build a Flask ``Response`` carrying Problem Details JSON.
+
+:param status: HTTP status code to emit.
+:type status: int
+:param title: Optional short summary of the problem.
+:type title: str | None
+:param detail: Extended explanation for clients.
+:type detail: str | None
+:param type: Canonical URI describing the problem type.
+:type type: str
+:param instance: URI reference that identifies the specific occurrence.
+:type instance: str | None
+:param code: Optional application error code.
+:type code: str | None
+:param errors: Structured validation details (list or mapping).
+:type errors: list[dict[str, Any]] | dict[str, Any] | None
+:returns: Flask response carrying ``application/problem+json`` payload.
+:rtype: flask.Response
+"""
+
+    status_enum = HTTPStatus(status)
+    payload: dict[str, Any] = {
+        "type": type,
+        "title": title or status_enum.phrase,
+        "status": status_enum.value,
+        "detail": detail,
+        "instance": instance or (request.path if request else None),
+    }
+    if code:
+        payload["code"] = code
+    if errors:
+        payload["errors"] = errors
+    response = jsonify(payload)
+    response.status_code = status_enum.value
+    response.mimetype = "application/problem+json"
+    return response
+
+
+def _handle_validation_error(err: ValidationError) -> Response:
+    """Convert Marshmallow validation errors into Problem Details responses.
+
+:param err: Validation error raised by Marshmallow.
+:type err: marshmallow.ValidationError
+:returns: Problem details response with ``422 Unprocessable Entity``.
+:rtype: flask.Response
+"""
+
+    return problem(
+        status=HTTPStatus.UNPROCESSABLE_ENTITY,
+        title="Validation Failed",
+        detail="Request body validation failed.",
+        code="validation_error",
+        errors=getattr(err, "messages", None),
+    )
+
+
+def register_problem_handlers(bp: Blueprint) -> None:
+    """Attach default Problem Details handlers to a blueprint.
+
+:param bp: Blueprint receiving handlers.
+:type bp: flask.Blueprint
+"""
+
+    @bp.errorhandler(HTTPException)
+    def _http_exception_handler(err: HTTPException) -> Response:
+        status = int(err.code or HTTPStatus.INTERNAL_SERVER_ERROR)
+        title = (err.name or HTTPStatus(status).phrase).strip()
+        detail = getattr(err, "description", None)
+        code = current_app.config.get("API_ERROR_CODE_MAP", {}).get(status)
+        return problem(status=status, title=title, detail=detail, code=code)
+
+    @bp.errorhandler(ValidationError)
+    def _marshmallow_error_handler(err: ValidationError) -> Response:
+        return _handle_validation_error(err)
+
+    @bp.errorhandler(Exception)
+    def _unhandled_error_handler(err: Exception) -> Response:
+        current_app.logger.exception("Unhandled API error", exc_info=err)
+        return problem(
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+            title="Internal Server Error",
+            detail="Unexpected error while processing the request.",
+            code="internal_server_error",
+        )

--- a/backend/app/api/etag.py
+++ b/backend/app/api/etag.py
@@ -1,0 +1,44 @@
+"""ETag helpers enabling optimistic concurrency for mutable resources."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from typing import Any
+
+from flask import Response
+
+
+def generate_etag(entity: Any) -> str | None:
+    """Generate a stable ETag value for a SQLAlchemy model instance.
+
+    The helper concatenates the entity primary key and ``updated_at`` timestamp
+    (when available) and hashes the string using SHA-256. When the entity lacks
+    an ``id`` attribute the function returns ``None`` to indicate ETag support
+    is not available.
+    """
+
+    identifier = getattr(entity, "id", None)
+    if identifier is None:
+        return None
+    updated_at: datetime | None = getattr(entity, "updated_at", None)
+    payload = f"{identifier}:{updated_at.isoformat() if updated_at else ''}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def verify_etag(entity: Any, provided: str | None) -> bool:
+    """Verify that a provided ETag matches the entity's current fingerprint."""
+
+    if not provided:
+        return False
+    current = generate_etag(entity)
+    return current == provided
+
+
+def set_response_etag(response: Response, entity: Any) -> Response:
+    """Attach an ``ETag`` header to a Flask response when possible."""
+
+    value = generate_etag(entity)
+    if value is not None:
+        response.set_etag(value)
+    return response

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1,0 +1,349 @@
+"""Marshmallow schemas dedicated to the versioned REST API."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from marshmallow import Schema, fields, validate
+
+
+class BaseSchema(Schema):
+    """Base schema enabling ordered output for consistent API responses."""
+
+    class Meta:
+        ordered = True
+
+
+class UserSchema(BaseSchema):
+    """Serialize ``User`` instances for API responses."""
+
+    id = fields.Int(dump_only=True)
+    email = fields.Email(required=True)
+    username = fields.String(required=True)
+    full_name = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+    subject_id = fields.Function(lambda obj: getattr(obj, "subject", None) and obj.subject.id, dump_only=True)
+
+
+class UserCreateSchema(UserSchema):
+    """Validate payloads when creating users."""
+
+    password = fields.String(required=True, load_only=True, validate=validate.Length(min=8))
+    subject_id = fields.Int(load_only=True, allow_none=True)
+
+
+class UserUpdateSchema(BaseSchema):
+    """Schema for partial user updates."""
+
+    email = fields.Email(load_only=True)
+    username = fields.String(load_only=True)
+    full_name = fields.String(load_only=True, allow_none=True)
+    password = fields.String(load_only=True, validate=validate.Length(min=8))
+
+
+class SubjectSchema(BaseSchema):
+    """Serialize ``Subject`` records."""
+
+    id = fields.Int(dump_only=True)
+    user_id = fields.Int(allow_none=True)
+    pseudonym = fields.UUID(dump_only=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class SubjectCreateSchema(BaseSchema):
+    """Validate subject creation requests."""
+
+    user_id = fields.Int(load_only=True, allow_none=True)
+
+
+class SubjectUpdateSchema(BaseSchema):
+    """Schema for patching subject data."""
+
+    user_id = fields.Int(load_only=True, allow_none=True)
+
+
+class SubjectProfileSchema(BaseSchema):
+    """Serialize and validate subject profile data."""
+
+    id = fields.Int(dump_only=True)
+    subject_id = fields.Int(dump_only=True)
+    sex = fields.String(validate=validate.OneOf(["MALE", "FEMALE", "OTHER", "PREFER_NOT_TO_SAY"]), allow_none=True)
+    birth_year = fields.Int(validate=validate.Range(min=1900, max=date.today().year), allow_none=True)
+    height_cm = fields.Int(validate=validate.Range(min=1), allow_none=True)
+    dominant_hand = fields.String(validate=validate.Length(max=10), allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class BodyMetricSchema(BaseSchema):
+    """Schema for subject body metrics time-series."""
+
+    id = fields.Int(dump_only=True)
+    subject_id = fields.Int(dump_only=True)
+    measured_on = fields.Date(required=True)
+    weight_kg = fields.Decimal(allow_none=True, as_string=True)
+    bodyfat_pct = fields.Decimal(allow_none=True, as_string=True)
+    resting_hr = fields.Int(allow_none=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class ExerciseSchema(BaseSchema):
+    """Serialize exercise catalog entries."""
+
+    id = fields.Int(dump_only=True)
+    name = fields.String(required=True)
+    slug = fields.String(required=True)
+    primary_muscle = fields.String(required=True)
+    movement = fields.String(required=True)
+    mechanics = fields.String(required=True)
+    force = fields.String(required=True)
+    unilateral = fields.Bool(required=True)
+    equipment = fields.String(required=True)
+    grip = fields.String(allow_none=True)
+    range_of_motion = fields.String(allow_none=True)
+    difficulty = fields.String(required=True)
+    cues = fields.String(allow_none=True)
+    instructions = fields.String(allow_none=True)
+    video_url = fields.String(allow_none=True)
+    is_active = fields.Bool(required=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class ExerciseCreateSchema(ExerciseSchema):
+    """Validation schema for creating exercises."""
+
+    id = fields.Int(dump_only=True)
+
+
+class ExerciseUpdateSchema(BaseSchema):
+    """Schema for partial exercise updates."""
+
+    name = fields.String(load_only=True)
+    slug = fields.String(load_only=True)
+    primary_muscle = fields.String(load_only=True)
+    movement = fields.String(load_only=True)
+    mechanics = fields.String(load_only=True)
+    force = fields.String(load_only=True)
+    unilateral = fields.Bool(load_only=True)
+    equipment = fields.String(load_only=True)
+    grip = fields.String(load_only=True, allow_none=True)
+    range_of_motion = fields.String(load_only=True, allow_none=True)
+    difficulty = fields.String(load_only=True)
+    cues = fields.String(load_only=True, allow_none=True)
+    instructions = fields.String(load_only=True, allow_none=True)
+    video_url = fields.String(load_only=True, allow_none=True)
+    is_active = fields.Bool(load_only=True)
+
+
+class RoutineSchema(BaseSchema):
+    """Serialize ``Routine`` templates."""
+
+    id = fields.Int(dump_only=True)
+    owner_subject_id = fields.Int(required=True)
+    name = fields.String(required=True)
+    description = fields.String(allow_none=True)
+    is_public = fields.Bool(required=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class RoutineCreateSchema(RoutineSchema):
+    """Schema validating routine creation."""
+
+    pass
+
+
+class RoutineUpdateSchema(BaseSchema):
+    """Schema for partial routine updates."""
+
+    name = fields.String(load_only=True)
+    description = fields.String(load_only=True, allow_none=True)
+    is_public = fields.Bool(load_only=True)
+
+
+class RoutineDaySchema(BaseSchema):
+    """Serialize routine day entities."""
+
+    id = fields.Int(dump_only=True)
+    routine_id = fields.Int(dump_only=True)
+    day_index = fields.Int(required=True)
+    is_rest = fields.Bool(required=True)
+    title = fields.String(allow_none=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class RoutineDayUpdateSchema(BaseSchema):
+    """Schema for routine day updates."""
+
+    day_index = fields.Int(load_only=True)
+    is_rest = fields.Bool(load_only=True)
+    title = fields.String(load_only=True, allow_none=True)
+    notes = fields.String(load_only=True, allow_none=True)
+
+
+class RoutineDayExerciseSchema(BaseSchema):
+    """Serialize exercises scheduled on a routine day."""
+
+    id = fields.Int(dump_only=True)
+    routine_day_id = fields.Int(dump_only=True)
+    exercise_id = fields.Int(required=True)
+    position = fields.Int(required=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class RoutineDayExerciseUpdateSchema(BaseSchema):
+    """Schema for updating routine day exercises."""
+
+    exercise_id = fields.Int(load_only=True)
+    position = fields.Int(load_only=True)
+    notes = fields.String(load_only=True, allow_none=True)
+
+
+class RoutineExerciseSetSchema(BaseSchema):
+    """Serialize planned set targets."""
+
+    id = fields.Int(dump_only=True)
+    routine_day_exercise_id = fields.Int(dump_only=True)
+    set_index = fields.Int(required=True)
+    is_warmup = fields.Bool(required=True)
+    to_failure = fields.Bool(required=True)
+    target_weight_kg = fields.Decimal(allow_none=True, as_string=True)
+    target_reps = fields.Int(allow_none=True)
+    target_rir = fields.Int(allow_none=True)
+    target_rpe = fields.Decimal(allow_none=True, as_string=True)
+    target_tempo = fields.String(allow_none=True)
+    target_rest_s = fields.Int(allow_none=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class RoutineExerciseSetUpdateSchema(BaseSchema):
+    """Schema for updating planned sets."""
+
+    set_index = fields.Int(load_only=True)
+    is_warmup = fields.Bool(load_only=True)
+    to_failure = fields.Bool(load_only=True)
+    target_weight_kg = fields.Decimal(load_only=True, allow_none=True, as_string=True)
+    target_reps = fields.Int(load_only=True, allow_none=True)
+    target_rir = fields.Int(load_only=True, allow_none=True)
+    target_rpe = fields.Decimal(load_only=True, allow_none=True, as_string=True)
+    target_tempo = fields.String(load_only=True, allow_none=True)
+    target_rest_s = fields.Int(load_only=True, allow_none=True)
+    notes = fields.String(load_only=True, allow_none=True)
+
+
+class SubjectRoutineSchema(BaseSchema):
+    """Serialize links between subjects and routines."""
+
+    id = fields.Int(dump_only=True)
+    subject_id = fields.Int(required=True)
+    routine_id = fields.Int(required=True)
+    is_active = fields.Bool(required=True)
+    saved_on = fields.DateTime(dump_only=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class CycleSchema(BaseSchema):
+    """Serialize routine execution cycles."""
+
+    id = fields.Int(dump_only=True)
+    subject_id = fields.Int(required=True)
+    routine_id = fields.Int(required=True)
+    cycle_number = fields.Int(required=True)
+    started_on = fields.Date(allow_none=True)
+    ended_on = fields.Date(allow_none=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class CycleUpdateSchema(BaseSchema):
+    """Schema for partial cycle updates."""
+
+    started_on = fields.Date(load_only=True, allow_none=True)
+    ended_on = fields.Date(load_only=True, allow_none=True)
+    notes = fields.String(load_only=True, allow_none=True)
+
+
+class WorkoutSessionSchema(BaseSchema):
+    """Serialize performed workout sessions."""
+
+    id = fields.Int(dump_only=True)
+    subject_id = fields.Int(required=True)
+    workout_date = fields.DateTime(required=True)
+    status = fields.String(required=True)
+    routine_day_id = fields.Int(allow_none=True)
+    cycle_id = fields.Int(allow_none=True)
+    location = fields.String(allow_none=True)
+    perceived_fatigue = fields.Int(allow_none=True)
+    bodyweight_kg = fields.Decimal(allow_none=True, as_string=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class WorkoutSessionUpdateSchema(BaseSchema):
+    """Schema for updating workout sessions."""
+
+    workout_date = fields.DateTime(load_only=True)
+    status = fields.String(load_only=True)
+    routine_day_id = fields.Int(load_only=True, allow_none=True)
+    cycle_id = fields.Int(load_only=True, allow_none=True)
+    location = fields.String(load_only=True, allow_none=True)
+    perceived_fatigue = fields.Int(load_only=True, allow_none=True)
+    bodyweight_kg = fields.Decimal(load_only=True, allow_none=True, as_string=True)
+    notes = fields.String(load_only=True, allow_none=True)
+
+
+class ExerciseSetLogSchema(BaseSchema):
+    """Serialize performed exercise sets."""
+
+    id = fields.Int(dump_only=True)
+    subject_id = fields.Int(required=True)
+    exercise_id = fields.Int(required=True)
+    session_id = fields.Int(allow_none=True)
+    planned_set_id = fields.Int(allow_none=True)
+    performed_at = fields.DateTime(required=True)
+    set_index = fields.Int(required=True)
+    is_warmup = fields.Bool(required=True)
+    to_failure = fields.Bool(required=True)
+    actual_weight_kg = fields.Decimal(allow_none=True, as_string=True)
+    actual_reps = fields.Int(allow_none=True)
+    actual_rir = fields.Int(allow_none=True)
+    actual_rpe = fields.Decimal(allow_none=True, as_string=True)
+    actual_tempo = fields.String(allow_none=True)
+    actual_rest_s = fields.Int(allow_none=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class ExerciseSetLogUpdateSchema(BaseSchema):
+    """Schema for updating exercise logs."""
+
+    exercise_id = fields.Int(load_only=True)
+    session_id = fields.Int(load_only=True, allow_none=True)
+    planned_set_id = fields.Int(load_only=True, allow_none=True)
+    performed_at = fields.DateTime(load_only=True)
+    set_index = fields.Int(load_only=True)
+    is_warmup = fields.Bool(load_only=True)
+    to_failure = fields.Bool(load_only=True)
+    actual_weight_kg = fields.Decimal(load_only=True, allow_none=True, as_string=True)
+    actual_reps = fields.Int(load_only=True, allow_none=True)
+    actual_rir = fields.Int(load_only=True, allow_none=True)
+    actual_rpe = fields.Decimal(load_only=True, allow_none=True, as_string=True)
+    actual_tempo = fields.String(load_only=True, allow_none=True)
+    actual_rest_s = fields.Int(load_only=True, allow_none=True)
+    notes = fields.String(load_only=True, allow_none=True)

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,17 +1,25 @@
-"""API v1 blueprint package bundling authentication and health routes."""
+"""Version 1 of the public REST API."""
 
 from __future__ import annotations
 
 from flask import Blueprint
 
-API_VERSION = "v1"
+api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
+"""Primary blueprint hosting the v1 REST surface."""
 
-# Import blueprints *only here* to keep imports localized and avoid cycles.
-from .auth import bp as auth_bp  # noqa: E402
-from .health import bp as health_bp  # noqa: E402
 
-# Each tuple: (blueprint, url_prefix_relative_to_version)
-REGISTRY: list[tuple[Blueprint, str]] = [
-    (health_bp, ""),  # -> /api/v1
-    (auth_bp, "/auth"),  # -> /api/v1/auth
-]
+def _register_modules() -> None:
+    """Import resource modules so route declarations are executed."""
+
+    from . import cycles  # noqa: F401
+    from . import exercises  # noqa: F401
+    from . import health  # noqa: F401
+    from . import routines  # noqa: F401
+    from . import subjects  # noqa: F401
+    from . import users  # noqa: F401
+    from . import workouts  # noqa: F401
+
+
+_register_modules()
+
+__all__ = ["api_v1"]

--- a/backend/app/api/v1/cycles.py
+++ b/backend/app/api/v1/cycles.py
@@ -1,0 +1,279 @@
+"""Cycle and subject-routine endpoints."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Response, request, url_for
+
+from app.models.cycle import Cycle
+from app.models.routine import Routine, SubjectRoutine
+from app.models.subject import Subject
+
+from .. import deps
+from ..errors import problem
+from ..etag import set_response_etag, verify_etag
+from ..schemas import (
+    CycleSchema,
+    CycleUpdateSchema,
+    SubjectRoutineSchema,
+)
+from . import api_v1
+
+cycle_schema = CycleSchema()
+cycles_schema = CycleSchema(many=True)
+cycle_update_schema = CycleUpdateSchema(partial=True)
+subject_routine_schema = SubjectRoutineSchema()
+subject_routines_schema = SubjectRoutineSchema(many=True)
+
+
+@api_v1.get("/cycles")
+@deps.timing
+def list_cycles() -> Response:
+    """List cycles filtered by subject, routine, or cycle number."""
+
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(Cycle)
+
+    subject_id = request.args.get("subject_id", type=int)
+    routine_id = request.args.get("routine_id", type=int)
+    cycle_number = request.args.get("cycle_number", type=int)
+
+    if subject_id is not None:
+        query = query.filter(Cycle.subject_id == subject_id)
+    if routine_id is not None:
+        query = query.filter(Cycle.routine_id == routine_id)
+    if cycle_number is not None:
+        query = query.filter(Cycle.cycle_number == cycle_number)
+
+    sort_map = {"started_on": Cycle.started_on, "created_at": Cycle.created_at}
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": cycles_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.get("/cycles/<int:cycle_id>")
+@deps.timing
+def retrieve_cycle(cycle_id: int) -> Response:
+    """Retrieve a single cycle."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    cycle = session.get(Cycle, cycle_id)
+    if cycle is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Cycle not found.", code="not_found")
+    response = deps.json_response(cycle_schema.dump(cycle))
+    return set_response_etag(response, cycle)
+
+
+@api_v1.post("/cycles")
+@deps.require_auth
+@deps.require_scope("cycles:write")
+@deps.timing
+def create_cycle() -> Response:
+    """Create a cycle linking a subject and routine."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = cycle_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    subject = session.get(Subject, data["subject_id"])
+    routine = session.get(Routine, data["routine_id"])
+    if subject is None or routine is None:
+        return problem(status=HTTPStatus.UNPROCESSABLE_ENTITY, detail="Subject or routine not found.", code="invalid_reference")
+
+    cycle = Cycle(**data)
+    session.add(cycle)
+    session.commit()
+
+    body = cycle_schema.dump(cycle)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, cycle)
+    response.headers["Location"] = url_for("api_v1.retrieve_cycle", cycle_id=cycle.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.patch("/cycles/<int:cycle_id>")
+@deps.require_auth
+@deps.require_scope("cycles:write")
+@deps.timing
+def update_cycle(cycle_id: int) -> Response:
+    """Patch cycle metadata such as dates or notes."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    cycle = session.get(Cycle, cycle_id)
+    if cycle is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Cycle not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(cycle, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = cycle_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(cycle, key, value)
+    session.commit()
+    response = deps.json_response(cycle_schema.dump(cycle))
+    return set_response_etag(response, cycle)
+
+
+@api_v1.delete("/cycles/<int:cycle_id>")
+@deps.require_auth
+@deps.require_scope("cycles:write")
+@deps.timing
+def delete_cycle(cycle_id: int) -> Response:
+    """Delete a cycle."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    cycle = session.get(Cycle, cycle_id)
+    if cycle is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Cycle not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(cycle, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(cycle)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)
+
+
+@api_v1.get("/subject-routines")
+@deps.timing
+def list_subject_routines() -> Response:
+    """List links between subjects and routines."""
+
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(SubjectRoutine)
+
+    subject_id = request.args.get("subject_id", type=int)
+    routine_id = request.args.get("routine_id", type=int)
+    is_active = request.args.get("is_active")
+
+    if subject_id is not None:
+        query = query.filter(SubjectRoutine.subject_id == subject_id)
+    if routine_id is not None:
+        query = query.filter(SubjectRoutine.routine_id == routine_id)
+    if is_active is not None:
+        query = query.filter(SubjectRoutine.is_active == (is_active.lower() != "false"))
+
+    sort_map = {"saved_on": SubjectRoutine.saved_on}
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": subject_routines_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.post("/subject-routines")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def create_subject_routine() -> Response:
+    """Create a subject-routine association."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = subject_routine_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    subject = session.get(Subject, data["subject_id"])
+    routine = session.get(Routine, data["routine_id"])
+    if subject is None or routine is None:
+        return problem(status=HTTPStatus.UNPROCESSABLE_ENTITY, detail="Subject or routine not found.", code="invalid_reference")
+
+    link = SubjectRoutine(**data)
+    session.add(link)
+    session.commit()
+
+    body = subject_routine_schema.dump(link)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, link)
+    response.headers["Location"] = url_for("api_v1.get_subject_routine", link_id=link.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.get("/subject-routines/<int:link_id>")
+@deps.timing
+def get_subject_routine(link_id: int) -> Response:
+    """Retrieve a subject-routine association."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    link = session.get(SubjectRoutine, link_id)
+    if link is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject routine link not found.", code="not_found")
+    response = deps.json_response(subject_routine_schema.dump(link))
+    return set_response_etag(response, link)
+
+
+@api_v1.delete("/subject-routines/<int:link_id>")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def delete_subject_routine(link_id: int) -> Response:
+    """Delete a subject-routine association."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    link = session.get(SubjectRoutine, link_id)
+    if link is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject routine link not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(link, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(link)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)

--- a/backend/app/api/v1/exercises.py
+++ b/backend/app/api/v1/exercises.py
@@ -1,0 +1,235 @@
+"""Exercise catalog endpoints and enumeration helpers."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Response, request, url_for
+from sqlalchemy.exc import IntegrityError
+
+from app.models.exercise import (
+    Equipment,
+    Exercise,
+    ForceVector,
+    Level,
+    Mechanics,
+    MovementPattern,
+    MuscleGroup,
+)
+
+from .. import deps
+from ..errors import problem
+from ..etag import set_response_etag, verify_etag
+from ..schemas import ExerciseCreateSchema, ExerciseSchema, ExerciseUpdateSchema
+from . import api_v1
+
+exercise_schema = ExerciseSchema()
+exercise_create_schema = ExerciseCreateSchema()
+exercise_update_schema = ExerciseUpdateSchema(partial=True)
+exercises_schema = ExerciseSchema(many=True)
+
+REFERENCE_ENUMS = {
+    "muscle-groups": [choice for choice in MuscleGroup.enums],
+    "equipment": [choice for choice in Equipment.enums],
+    "mechanics": [choice for choice in Mechanics.enums],
+    "force-vectors": [choice for choice in ForceVector.enums],
+    "levels": [choice for choice in Level.enums],
+    "movement-patterns": [choice for choice in MovementPattern.enums],
+}
+
+
+@api_v1.get("/exercises")
+@deps.timing
+def list_exercises() -> Response:
+    """List exercises with filters, sorting, and pagination.
+
+    :returns: Envelope containing serialized exercises.
+    :rtype: flask.Response
+    """
+
+    # Build a catalog query and apply filter parameters.
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(Exercise)
+
+    name = request.args.get("name")
+    primary_muscle = request.args.get("primary_muscle")
+    equipment = request.args.get("equipment")
+    is_active = request.args.get("is_active")
+
+    if name:
+        query = query.filter(Exercise.name.ilike(f"%{name}%"))
+    if primary_muscle:
+        query = query.filter(Exercise.primary_muscle == primary_muscle)
+    if equipment:
+        query = query.filter(Exercise.equipment == equipment)
+    if is_active is not None:
+        query = query.filter(Exercise.is_active == (is_active.lower() != "false"))
+
+    sort_map = {
+        "name": Exercise.name,
+        "created_at": Exercise.created_at,
+        "difficulty": Exercise.difficulty,
+    }
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": exercises_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.get("/exercises/<int:exercise_id>")
+@deps.timing
+def retrieve_exercise(exercise_id: int) -> Response:
+    """Fetch exercise details.
+
+    :param exercise_id: Exercise identifier.
+    :type exercise_id: int
+    :returns: Serialized exercise record with ETag header.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the exercise or return a problem response.
+    exercise = session.get(Exercise, exercise_id)
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Exercise not found.", code="not_found")
+    response = deps.json_response(exercise_schema.dump(exercise))
+    return set_response_etag(response, exercise)
+
+
+@api_v1.post("/exercises")
+@deps.require_auth
+@deps.require_scope("exercises:write")
+@deps.timing
+def create_exercise() -> Response:
+    """Create an exercise entry.
+
+    :returns: Newly created exercise resource.
+    :rtype: flask.Response
+    """
+
+    # Idempotency safeguards protect against duplicate catalog entries.
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = exercise_create_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    exercise = Exercise(**data)
+    session.add(exercise)
+    try:
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        return problem(status=HTTPStatus.CONFLICT, detail="Exercise with same slug exists.", code="conflict")
+
+    body = exercise_schema.dump(exercise)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, exercise)
+    response.headers["Location"] = url_for("api_v1.retrieve_exercise", exercise_id=exercise.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.patch("/exercises/<int:exercise_id>")
+@deps.require_auth
+@deps.require_scope("exercises:write")
+@deps.timing
+def update_exercise(exercise_id: int) -> Response:
+    """Partially update an exercise.
+
+    :param exercise_id: Exercise identifier.
+    :type exercise_id: int
+    :returns: Updated exercise payload.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the exercise or return a problem response.
+    exercise = session.get(Exercise, exercise_id)
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Exercise not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(exercise, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    # Apply partial updates only to fields provided by the client.
+    data = exercise_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(exercise, key, value)
+    session.commit()
+    response = deps.json_response(exercise_schema.dump(exercise))
+    return set_response_etag(response, exercise)
+
+
+@api_v1.delete("/exercises/<int:exercise_id>")
+@deps.require_auth
+@deps.require_scope("exercises:write")
+@deps.timing
+def delete_exercise(exercise_id: int) -> Response:
+    """Soft delete an exercise by marking it inactive.
+
+    :param exercise_id: Exercise identifier.
+    :type exercise_id: int
+    :returns: Updated exercise payload reflecting the inactive state.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the exercise or return a problem response.
+    exercise = session.get(Exercise, exercise_id)
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Exercise not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(exercise, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    exercise.is_active = False
+    session.commit()
+    response = deps.json_response(exercise_schema.dump(exercise))
+    return set_response_etag(response, exercise)
+
+
+@api_v1.get("/exercises/meta/<string:name>")
+@deps.timing
+def exercise_reference_data(name: str) -> Response:
+    """Expose read-only exercise enumeration values.
+
+    :param name: Enumeration name (e.g., ``muscle-groups``).
+    :type name: str
+    :returns: JSON payload with enumeration members or 404.
+    :rtype: flask.Response
+    """
+
+    values = REFERENCE_ENUMS.get(name)
+    if values is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Enumeration not found.", code="not_found")
+    payload = {"name": name, "values": values}
+    return deps.json_response(payload)

--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -1,36 +1,46 @@
-"""Health and readiness endpoints for uptime checks."""
+"""Health endpoints for Kubernetes-style probes."""
 
 from __future__ import annotations
 
-from flask import Blueprint
+import time
+from http import HTTPStatus
 
-bp = Blueprint("health", __name__)
+from flask import current_app
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.core.extensions import db
+
+from ..deps import json_response, timing
+from . import api_v1
 
 
-@bp.get("/healthz")
-def healthz():
-    """Report basic process health for liveness probes.
+@api_v1.get("/health")
+@timing
+def health() -> tuple[dict[str, object], int]:
+    """Return service and database status information.
 
-    Returns
-    -------
-    dict[str, str]
-        Payload containing a static ``status`` field with value ``"ok"``.
+    The handler executes ``SELECT 1`` to validate the database connection and
+    returns a JSON payload compatible with uptime monitors.
+
+    :returns: Tuple containing the payload dictionary and HTTP status code.
+    :rtype: tuple[dict[str, object], int]
     """
-    return {"status": "ok"}
 
-
-@bp.get("/readiness")
-def readiness():
-    """Indicate the service is ready to handle traffic.
-
-    Returns
-    -------
-    dict[str, bool]
-        Payload containing ``ready`` to signal readiness to orchestrators.
-
-    Notes
-    -----
-    No downstream health checks are performed yet; the endpoint only reflects
-    process-level readiness.
-    """
-    return {"ready": True}
+    # Measure timing to surface latency in the payload.
+    started = time.perf_counter()
+    db_status = "up"
+    try:
+        # Issue a lightweight query to ensure the primary database is reachable.
+        db.session.execute(text("SELECT 1"))
+    except SQLAlchemyError as exc:  # pragma: no cover - exercised in production outages
+        current_app.logger.exception("Health DB check failed", exc_info=exc)
+        db_status = "down"
+    latency_ms = round((time.perf_counter() - started) * 1000, 2)
+    status_code = HTTPStatus.OK if db_status == "up" else HTTPStatus.SERVICE_UNAVAILABLE
+    payload = {
+        "status": "ok" if status_code == HTTPStatus.OK else "degraded",
+        "db": {"status": db_status},
+        "latency_ms": latency_ms,
+    }
+    return payload, status_code.value

--- a/backend/app/api/v1/routines.py
+++ b/backend/app/api/v1/routines.py
@@ -1,0 +1,735 @@
+"""Routine template endpoints including nested hierarchy management."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Response, request, url_for
+
+from app.models.routine import (
+    Routine,
+    RoutineDay,
+    RoutineDayExercise,
+    RoutineExerciseSet,
+)
+
+from .. import deps
+from ..errors import problem
+from ..etag import set_response_etag, verify_etag
+from ..schemas import (
+    RoutineCreateSchema,
+    RoutineDayExerciseSchema,
+    RoutineDayExerciseUpdateSchema,
+    RoutineDaySchema,
+    RoutineDayUpdateSchema,
+    RoutineExerciseSetSchema,
+    RoutineExerciseSetUpdateSchema,
+    RoutineSchema,
+    RoutineUpdateSchema,
+)
+from . import api_v1
+
+routine_schema = RoutineSchema()
+routines_schema = RoutineSchema(many=True)
+routine_create_schema = RoutineCreateSchema()
+routine_update_schema = RoutineUpdateSchema(partial=True)
+routine_day_schema = RoutineDaySchema()
+routine_days_schema = RoutineDaySchema(many=True)
+routine_day_update_schema = RoutineDayUpdateSchema(partial=True)
+routine_day_exercise_schema = RoutineDayExerciseSchema()
+routine_day_exercises_schema = RoutineDayExerciseSchema(many=True)
+routine_day_exercise_update_schema = RoutineDayExerciseUpdateSchema(partial=True)
+routine_set_schema = RoutineExerciseSetSchema()
+routine_sets_schema = RoutineExerciseSetSchema(many=True)
+routine_set_update_schema = RoutineExerciseSetUpdateSchema(partial=True)
+
+
+@api_v1.get("/routines")
+@deps.timing
+def list_routines() -> Response:
+    """Return paginated routines filtered by owner or name.
+
+    :returns: Standard pagination envelope with routine data.
+    :rtype: flask.Response
+    """
+
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(Routine)
+
+    owner_subject_id = request.args.get("owner_subject_id", type=int)
+    name = request.args.get("name")
+    is_public = request.args.get("is_public")
+
+    if owner_subject_id is not None:
+        query = query.filter(Routine.owner_subject_id == owner_subject_id)
+    if name:
+        query = query.filter(Routine.name.ilike(f"%{name}%"))
+    if is_public is not None:
+        query = query.filter(Routine.is_public == (is_public.lower() != "false"))
+
+    sort_map = {"created_at": Routine.created_at, "name": Routine.name}
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": routines_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.get("/routines/<int:routine_id>")
+@deps.timing
+def retrieve_routine(routine_id: int) -> Response:
+    """Retrieve a single routine by identifier.
+
+    :param routine_id: Routine identifier.
+    :type routine_id: int
+    :returns: Routine payload with ETag header.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine = session.get(Routine, routine_id)
+    if routine is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine not found.", code="not_found")
+    response = deps.json_response(routine_schema.dump(routine))
+    return set_response_etag(response, routine)
+
+
+@api_v1.post("/routines")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def create_routine() -> Response:
+    """Create a routine template.
+
+    :returns: Serialized routine with ``201 Created``.
+    :rtype: flask.Response
+    """
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_create_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine = Routine(**data)
+    session.add(routine)
+    session.commit()
+
+    body = routine_schema.dump(routine)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, routine)
+    response.headers["Location"] = url_for("api_v1.retrieve_routine", routine_id=routine.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.patch("/routines/<int:routine_id>")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def update_routine(routine_id: int) -> Response:
+    """Patch routine metadata.
+
+    :param routine_id: Routine identifier.
+    :type routine_id: int
+    :returns: Updated routine payload.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine = session.get(Routine, routine_id)
+    if routine is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(routine, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(routine, key, value)
+    session.commit()
+
+    response = deps.json_response(routine_schema.dump(routine))
+    return set_response_etag(response, routine)
+
+
+@api_v1.delete("/routines/<int:routine_id>")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def delete_routine(routine_id: int) -> Response:
+    """Delete a routine and its hierarchy.
+
+    :param routine_id: Routine identifier.
+    :type routine_id: int
+    :returns: ``204 No Content`` when deletion succeeds.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine = session.get(Routine, routine_id)
+    if routine is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(routine, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(routine)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)
+
+
+@api_v1.get("/routines/<int:routine_id>/days")
+@deps.timing
+def list_routine_days(routine_id: int) -> Response:
+    """List routine days for a template.
+
+    :param routine_id: Routine identifier.
+    :type routine_id: int
+    :returns: Collection of routine days.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine = session.get(Routine, routine_id)
+    if routine is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine not found.", code="not_found")
+
+    query = session.query(RoutineDay).filter(RoutineDay.routine_id == routine.id)
+    pagination = deps.parse_pagination()
+    sort_map = {"day_index": RoutineDay.day_index}
+    query = deps.apply_sorting(query, sort_map, pagination.sort or ["day_index"])
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": routine_days_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.post("/routines/<int:routine_id>/days")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def create_routine_day(routine_id: int) -> Response:
+    """Create a routine day entry.
+
+    :param routine_id: Parent routine identifier.
+    :type routine_id: int
+    :returns: Created routine day payload.
+    :rtype: flask.Response
+    """
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine = session.get(Routine, routine_id)
+    if routine is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine not found.", code="not_found")
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_day_schema.load(payload)
+    day = RoutineDay(routine_id=routine.id, **data)
+    session.add(day)
+    session.commit()
+
+    body = routine_day_schema.dump(day)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, day)
+    response.headers["Location"] = url_for("api_v1.get_routine_day", routine_id=routine.id, day_id=day.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.get("/routines/<int:routine_id>/days/<int:day_id>")
+@deps.timing
+def get_routine_day(routine_id: int, day_id: int) -> Response:
+    """Retrieve a routine day.
+
+    :param routine_id: Parent routine identifier.
+    :type routine_id: int
+    :param day_id: Routine day identifier.
+    :type day_id: int
+    :returns: Serialized routine day payload.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    day = (
+        session.query(RoutineDay)
+        .filter(RoutineDay.routine_id == routine_id, RoutineDay.id == day_id)
+        .first()
+    )
+    if day is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day not found.", code="not_found")
+    response = deps.json_response(routine_day_schema.dump(day))
+    return set_response_etag(response, day)
+
+
+@api_v1.patch("/routines/<int:routine_id>/days/<int:day_id>")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def update_routine_day(routine_id: int, day_id: int) -> Response:
+    """Patch a routine day.
+
+    :param routine_id: Parent routine identifier.
+    :type routine_id: int
+    :param day_id: Routine day identifier.
+    :type day_id: int
+    :returns: Updated routine day payload.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    day = (
+        session.query(RoutineDay)
+        .filter(RoutineDay.routine_id == routine_id, RoutineDay.id == day_id)
+        .first()
+    )
+    if day is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(day, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_day_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(day, key, value)
+    session.commit()
+    response = deps.json_response(routine_day_schema.dump(day))
+    return set_response_etag(response, day)
+
+
+@api_v1.delete("/routines/<int:routine_id>/days/<int:day_id>")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def delete_routine_day(routine_id: int, day_id: int) -> Response:
+    """Delete a routine day."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    day = (
+        session.query(RoutineDay)
+        .filter(RoutineDay.routine_id == routine_id, RoutineDay.id == day_id)
+        .first()
+    )
+    if day is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(day, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(day)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)
+
+
+@api_v1.get("/routines/<int:routine_id>/days/<int:day_id>/exercises")
+@deps.timing
+def list_routine_day_exercises(routine_id: int, day_id: int) -> Response:
+    """List exercises configured for a routine day."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    day = (
+        session.query(RoutineDay)
+        .filter(RoutineDay.routine_id == routine_id, RoutineDay.id == day_id)
+        .first()
+    )
+    if day is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day not found.", code="not_found")
+
+    query = session.query(RoutineDayExercise).filter(RoutineDayExercise.routine_day_id == day.id)
+    pagination = deps.parse_pagination()
+    sort_map = {"position": RoutineDayExercise.position}
+    query = deps.apply_sorting(query, sort_map, pagination.sort or ["position"])
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": routine_day_exercises_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.post("/routines/<int:routine_id>/days/<int:day_id>/exercises")
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def create_routine_day_exercise(routine_id: int, day_id: int) -> Response:
+    """Create a planned exercise for a routine day."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    day = (
+        session.query(RoutineDay)
+        .filter(RoutineDay.routine_id == routine_id, RoutineDay.id == day_id)
+        .first()
+    )
+    if day is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day not found.", code="not_found")
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_day_exercise_schema.load(payload)
+    exercise = RoutineDayExercise(routine_day_id=day.id, **data)
+    session.add(exercise)
+    session.commit()
+
+    body = routine_day_exercise_schema.dump(exercise)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, exercise)
+    response.headers["Location"] = url_for(
+        "api_v1.get_routine_day_exercise", routine_id=routine_id, day_id=day_id, exercise_id=exercise.id
+    )
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.get("/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>")
+@deps.timing
+def get_routine_day_exercise(routine_id: int, day_id: int, exercise_id: int) -> Response:
+    """Retrieve a routine day exercise entry."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    exercise = (
+        session.query(RoutineDayExercise)
+        .filter(
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.id == exercise_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day exercise not found.", code="not_found")
+    response = deps.json_response(routine_day_exercise_schema.dump(exercise))
+    return set_response_etag(response, exercise)
+
+
+@api_v1.patch(
+    "/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>"
+)
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def update_routine_day_exercise(routine_id: int, day_id: int, exercise_id: int) -> Response:
+    """Patch a routine day exercise."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    exercise = (
+        session.query(RoutineDayExercise)
+        .filter(
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.id == exercise_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day exercise not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(exercise, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_day_exercise_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(exercise, key, value)
+    session.commit()
+    response = deps.json_response(routine_day_exercise_schema.dump(exercise))
+    return set_response_etag(response, exercise)
+
+
+@api_v1.delete(
+    "/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>"
+)
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def delete_routine_day_exercise(routine_id: int, day_id: int, exercise_id: int) -> Response:
+    """Delete a routine day exercise."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    exercise = (
+        session.query(RoutineDayExercise)
+        .filter(
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.id == exercise_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day exercise not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(exercise, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(exercise)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)
+
+
+@api_v1.get(
+    "/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>/sets"
+)
+@deps.timing
+def list_routine_sets(routine_id: int, day_id: int, exercise_id: int) -> Response:
+    """List planned sets for a routine day exercise."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    exercise = (
+        session.query(RoutineDayExercise)
+        .filter(
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.id == exercise_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day exercise not found.", code="not_found")
+
+    query = session.query(RoutineExerciseSet).filter(RoutineExerciseSet.routine_day_exercise_id == exercise.id)
+    pagination = deps.parse_pagination()
+    sort_map = {"set_index": RoutineExerciseSet.set_index}
+    query = deps.apply_sorting(query, sort_map, pagination.sort or ["set_index"])
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": routine_sets_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.post(
+    "/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>/sets"
+)
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def create_routine_set(routine_id: int, day_id: int, exercise_id: int) -> Response:
+    """Create a planned set for a routine exercise."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    exercise = (
+        session.query(RoutineDayExercise)
+        .filter(
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.id == exercise_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if exercise is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine day exercise not found.", code="not_found")
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_set_schema.load(payload)
+    routine_set = RoutineExerciseSet(routine_day_exercise_id=exercise.id, **data)
+    session.add(routine_set)
+    session.commit()
+
+    body = routine_set_schema.dump(routine_set)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, routine_set)
+    response.headers["Location"] = url_for(
+        "api_v1.get_routine_set",
+        routine_id=routine_id,
+        day_id=day_id,
+        exercise_id=exercise_id,
+        set_id=routine_set.id,
+    )
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.get(
+    "/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>/sets/<int:set_id>"
+)
+@deps.timing
+def get_routine_set(routine_id: int, day_id: int, exercise_id: int, set_id: int) -> Response:
+    """Retrieve a planned set."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine_set = (
+        session.query(RoutineExerciseSet)
+        .join(RoutineDayExercise)
+        .filter(
+            RoutineExerciseSet.id == set_id,
+            RoutineExerciseSet.routine_day_exercise_id == exercise_id,
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if routine_set is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine set not found.", code="not_found")
+    response = deps.json_response(routine_set_schema.dump(routine_set))
+    return set_response_etag(response, routine_set)
+
+
+@api_v1.patch(
+    "/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>/sets/<int:set_id>"
+)
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def update_routine_set(
+    routine_id: int, day_id: int, exercise_id: int, set_id: int
+) -> Response:
+    """Patch a planned routine set."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine_set = (
+        session.query(RoutineExerciseSet)
+        .join(RoutineDayExercise)
+        .filter(
+            RoutineExerciseSet.id == set_id,
+            RoutineExerciseSet.routine_day_exercise_id == exercise_id,
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if routine_set is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine set not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(routine_set, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = routine_set_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(routine_set, key, value)
+    session.commit()
+    response = deps.json_response(routine_set_schema.dump(routine_set))
+    return set_response_etag(response, routine_set)
+
+
+@api_v1.delete(
+    "/routines/<int:routine_id>/days/<int:day_id>/exercises/<int:exercise_id>/sets/<int:set_id>"
+)
+@deps.require_auth
+@deps.require_scope("routines:write")
+@deps.timing
+def delete_routine_set(routine_id: int, day_id: int, exercise_id: int, set_id: int) -> Response:
+    """Delete a planned routine set."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    routine_set = (
+        session.query(RoutineExerciseSet)
+        .join(RoutineDayExercise)
+        .filter(
+            RoutineExerciseSet.id == set_id,
+            RoutineExerciseSet.routine_day_exercise_id == exercise_id,
+            RoutineDayExercise.routine_day_id == day_id,
+            RoutineDayExercise.routine_day.has(RoutineDay.routine_id == routine_id),
+        )
+        .first()
+    )
+    if routine_set is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Routine set not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(routine_set, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(routine_set)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)

--- a/backend/app/api/v1/subjects.py
+++ b/backend/app/api/v1/subjects.py
@@ -1,0 +1,471 @@
+"""Subject resource endpoints including profiles and metrics."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from datetime import date
+
+from flask import Response, request, url_for
+
+from app.models.subject import Subject, SubjectBodyMetrics, SubjectProfile
+
+from .. import deps
+from ..errors import problem
+from ..etag import set_response_etag, verify_etag
+from ..schemas import (
+    BodyMetricSchema,
+    SubjectCreateSchema,
+    SubjectProfileSchema,
+    SubjectSchema,
+    SubjectUpdateSchema,
+)
+from . import api_v1
+
+subject_schema = SubjectSchema()
+subjects_schema = SubjectSchema(many=True)
+subject_create_schema = SubjectCreateSchema()
+subject_update_schema = SubjectUpdateSchema(partial=True)
+profile_schema = SubjectProfileSchema()
+body_metric_schema = BodyMetricSchema()
+body_metrics_schema = BodyMetricSchema(many=True)
+body_metric_update_schema = BodyMetricSchema(partial=True)
+
+
+@api_v1.get("/subjects")
+@deps.timing
+def list_subjects() -> Response:
+    """Return a paginated list of subjects.
+
+    :returns: JSON response containing the standard pagination envelope.
+    :rtype: flask.Response
+    """
+
+    # Build the base query and honor query-string filters.
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(Subject)
+
+    user_id = request.args.get("user_id", type=int)
+    pseudonym = request.args.get("pseudonym")
+    if user_id is not None:
+        query = query.filter(Subject.user_id == user_id)
+    if pseudonym:
+        query = query.filter(Subject.pseudonym == pseudonym)
+
+    sort_map = {"id": Subject.id, "created_at": Subject.created_at}
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": subjects_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.get("/subjects/<int:subject_id>")
+@deps.timing
+def retrieve_subject(subject_id: int) -> Response:
+    """Retrieve a subject by identifier.
+
+    :param subject_id: Subject primary key.
+    :type subject_id: int
+    :returns: Serialized subject payload with ETag header.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the subject or respond with a Problem document.
+    subject = session.get(Subject, subject_id)
+    if subject is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject not found.", code="not_found")
+    response = deps.json_response(subject_schema.dump(subject))
+    return set_response_etag(response, subject)
+
+
+@api_v1.post("/subjects")
+@deps.require_auth
+@deps.require_scope("subjects:write")
+@deps.timing
+def create_subject() -> Response:
+    """Create a new subject entity.
+
+    :returns: Serialized subject payload with ``201 Created``.
+    :rtype: flask.Response
+    """
+
+    # Enforce idempotency before any database writes.
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = subject_create_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    subject = Subject(user_id=data.get("user_id"))
+    session.add(subject)
+    session.commit()
+
+    body = subject_schema.dump(subject)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, subject)
+    response.headers["Location"] = url_for("api_v1.retrieve_subject", subject_id=subject.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.patch("/subjects/<int:subject_id>")
+@deps.require_auth
+@deps.require_scope("subjects:write")
+@deps.timing
+def update_subject(subject_id: int) -> Response:
+    """Partially update a subject.
+
+    :param subject_id: Subject identifier to mutate.
+    :type subject_id: int
+    :returns: Updated subject representation.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the subject or respond with a Problem document.
+    subject = session.get(Subject, subject_id)
+    if subject is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject not found.", code="not_found")
+
+    # Require clients to present the latest ETag.
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(subject, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = subject_update_schema.load(payload)
+
+    if "user_id" in data:
+        subject.user_id = data["user_id"]
+
+    session.commit()
+    response = deps.json_response(subject_schema.dump(subject))
+    return set_response_etag(response, subject)
+
+
+@api_v1.delete("/subjects/<int:subject_id>")
+@deps.require_auth
+@deps.require_scope("subjects:write")
+@deps.timing
+def delete_subject(subject_id: int) -> Response:
+    """Delete a subject and cascading domain data.
+
+    :param subject_id: Subject identifier to delete.
+    :type subject_id: int
+    :returns: Empty ``204 No Content`` response when deletion succeeds.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the subject or respond with a Problem document.
+    subject = session.get(Subject, subject_id)
+    if subject is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject not found.", code="not_found")
+
+    # Require clients to present the latest ETag.
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(subject, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(subject)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)
+
+
+@api_v1.get("/subjects/<int:subject_id>/profile")
+@deps.timing
+def get_subject_profile(subject_id: int) -> Response:
+    """Return a subject profile document.
+
+    :param subject_id: Parent subject identifier.
+    :type subject_id: int
+    :returns: Profile payload or 404 when missing.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the subject or respond with a Problem document.
+    subject = session.get(Subject, subject_id)
+    if subject is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject not found.", code="not_found")
+    # Reuse the relationship to access or build the profile.
+    profile = subject.profile
+    if profile is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Profile not found.", code="not_found")
+    response = deps.json_response(profile_schema.dump(profile))
+    return set_response_etag(response, profile)
+
+
+@api_v1.put("/subjects/<int:subject_id>/profile")
+@deps.require_auth
+@deps.require_scope("subjects:write")
+@deps.timing
+def upsert_subject_profile(subject_id: int) -> Response:
+    """Create or replace a subject profile.
+
+    Existing profiles require ``If-Match`` to avoid lost updates.
+
+    :param subject_id: Parent subject identifier.
+    :type subject_id: int
+    :returns: Updated or created profile representation.
+    :rtype: flask.Response
+    """
+
+    payload = request.get_json(silent=True) or {}
+    data = profile_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the subject or respond with a Problem document.
+    subject = session.get(Subject, subject_id)
+    if subject is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject not found.", code="not_found")
+
+    # Reuse the relationship to access or build the profile.
+    profile = subject.profile
+    if profile is None:
+        profile = SubjectProfile(subject_id=subject.id)
+        session.add(profile)
+    else:
+        # Require clients to present the latest ETag.
+        if_match = request.headers.get("If-Match")
+        if not if_match:
+            return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+        if not verify_etag(profile, if_match.strip('"')):
+            return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    for key, value in data.items():
+        if key != "id":
+            setattr(profile, key, value)
+
+    session.commit()
+    response = deps.json_response(profile_schema.dump(profile))
+    return set_response_etag(response, profile)
+
+
+@api_v1.get("/subjects/<int:subject_id>/body-metrics")
+@deps.timing
+def list_body_metrics(subject_id: int) -> Response:
+    """List body metrics for a subject.
+
+    :param subject_id: Parent subject identifier.
+    :type subject_id: int
+    :returns: Paginated envelope of measurements.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the subject or respond with a Problem document.
+    subject = session.get(Subject, subject_id)
+    if subject is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject not found.", code="not_found")
+
+    # Build the base query and honor query-string filters.
+    pagination = deps.parse_pagination()
+    # Scope the metrics query to the parent subject.
+    query = session.query(SubjectBodyMetrics).filter(SubjectBodyMetrics.subject_id == subject.id)
+
+    measured_on = request.args.get("measured_on")
+    if measured_on:
+        try:
+            measured_date = date.fromisoformat(measured_on)
+        except ValueError:
+            return problem(status=HTTPStatus.BAD_REQUEST, detail="Invalid measured_on date format.", code="invalid_date")
+        query = query.filter(SubjectBodyMetrics.measured_on == measured_date)
+
+    sort_map = {"measured_on": SubjectBodyMetrics.measured_on, "created_at": SubjectBodyMetrics.created_at}
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": body_metrics_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.post("/subjects/<int:subject_id>/body-metrics")
+@deps.require_auth
+@deps.require_scope("subjects:write")
+@deps.timing
+def create_body_metric(subject_id: int) -> Response:
+    """Create a body metric entry for a subject.
+
+    :param subject_id: Parent subject identifier.
+    :type subject_id: int
+    :returns: Created metric document.
+    :rtype: flask.Response
+    """
+
+    # Enforce idempotency before any database writes.
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = body_metric_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Resolve the subject or respond with a Problem document.
+    subject = session.get(Subject, subject_id)
+    if subject is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Subject not found.", code="not_found")
+
+    metric = SubjectBodyMetrics(subject_id=subject.id, **data)
+    session.add(metric)
+    session.commit()
+
+    body = body_metric_schema.dump(metric)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, metric)
+    response.headers["Location"] = url_for(
+        "api_v1.get_body_metric", subject_id=subject.id, metric_id=metric.id
+    )
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.get("/subjects/<int:subject_id>/body-metrics/<int:metric_id>")
+@deps.timing
+def get_body_metric(subject_id: int, metric_id: int) -> Response:
+    """Retrieve a single body metric entry.
+
+    :param subject_id: Parent subject identifier.
+    :type subject_id: int
+    :param metric_id: Metric identifier.
+    :type metric_id: int
+    :returns: Serialized metric payload.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Locate the metric within the parent subject namespace.
+    metric = (
+        session.query(SubjectBodyMetrics)
+        .filter(SubjectBodyMetrics.subject_id == subject_id, SubjectBodyMetrics.id == metric_id)
+        .first()
+    )
+    if metric is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Metric not found.", code="not_found")
+    response = deps.json_response(body_metric_schema.dump(metric))
+    return set_response_etag(response, metric)
+
+
+@api_v1.patch("/subjects/<int:subject_id>/body-metrics/<int:metric_id>")
+@deps.require_auth
+@deps.require_scope("subjects:write")
+@deps.timing
+def update_body_metric(subject_id: int, metric_id: int) -> Response:
+    """Patch a body metric entry.
+
+    :param subject_id: Parent subject identifier.
+    :type subject_id: int
+    :param metric_id: Metric identifier.
+    :type metric_id: int
+    :returns: Updated metric representation.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Locate the metric within the parent subject namespace.
+    metric = (
+        session.query(SubjectBodyMetrics)
+        .filter(SubjectBodyMetrics.subject_id == subject_id, SubjectBodyMetrics.id == metric_id)
+        .first()
+    )
+    if metric is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Metric not found.", code="not_found")
+
+    # Require clients to present the latest ETag.
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(metric, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = body_metric_update_schema.load(payload)
+
+    for key, value in data.items():
+        setattr(metric, key, value)
+
+    session.commit()
+    response = deps.json_response(body_metric_schema.dump(metric))
+    return set_response_etag(response, metric)
+
+
+@api_v1.delete("/subjects/<int:subject_id>/body-metrics/<int:metric_id>")
+@deps.require_auth
+@deps.require_scope("subjects:write")
+@deps.timing
+def delete_body_metric(subject_id: int, metric_id: int) -> Response:
+    """Delete a body metric entry.
+
+    :param subject_id: Parent subject identifier.
+    :type subject_id: int
+    :param metric_id: Metric identifier.
+    :type metric_id: int
+    :returns: Empty ``204 No Content`` response.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Locate the metric within the parent subject namespace.
+    metric = (
+        session.query(SubjectBodyMetrics)
+        .filter(SubjectBodyMetrics.subject_id == subject_id, SubjectBodyMetrics.id == metric_id)
+        .first()
+    )
+    if metric is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Metric not found.", code="not_found")
+
+    # Require clients to present the latest ETag.
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(metric, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(metric)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -1,0 +1,221 @@
+"""User resource endpoints."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Response, request, url_for
+
+from app.models.subject import Subject
+from app.models.user import User
+
+from .. import deps
+from ..errors import problem
+from ..etag import set_response_etag, verify_etag
+from ..schemas import UserCreateSchema, UserSchema, UserUpdateSchema
+from . import api_v1
+
+user_schema = UserSchema()
+users_schema = UserSchema(many=True)
+user_create_schema = UserCreateSchema()
+user_update_schema = UserUpdateSchema(partial=True)
+
+
+@api_v1.get("/users")
+@deps.timing
+def list_users() -> Response:
+    """List users with pagination, filtering, and sorting.
+
+    :returns: JSON response containing the standard pagination envelope.
+    :rtype: flask.Response
+    """
+
+    # Build the base query and apply client-provided filters.
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(User)
+
+    email = request.args.get("email")
+    username = request.args.get("username")
+    if email:
+        query = query.filter(User.email == email)
+    if username:
+        query = query.filter(User.username == username)
+
+    sort_map = {
+        "id": User.id,
+        "created_at": User.created_at,
+        "username": User.username,
+    }
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": users_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.get("/users/<int:user_id>")
+@deps.timing
+def retrieve_user(user_id: int) -> Response:
+    """Retrieve a single user by identifier.
+
+    :param user_id: Database identifier of the requested user.
+    :type user_id: int
+    :returns: Serialized user payload with ETag header.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Fetch the requested user or produce a 404 problem response.
+    user = session.get(User, user_id)
+    if user is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="User not found.", code="not_found")
+    response = deps.json_response(user_schema.dump(user))
+    return set_response_etag(response, user)
+
+
+@api_v1.post("/users")
+@deps.require_auth
+@deps.require_scope("users:write")
+@deps.timing
+def create_user() -> Response:
+    """Create a new user after validating the payload.
+
+    The handler expects an ``Idempotency-Key`` header so safe retries can
+    reuse prior results. Passwords are hashed using the model helper.
+
+    :returns: Newly created user document with ``201 Created``.
+    :rtype: flask.Response
+    """
+
+    # Enforce idempotency semantics before mutating state.
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = user_create_schema.load(payload)
+    # Acquire a session for database work.
+    session = deps.get_session()
+
+    user = User(
+        email=data["email"],
+        username=data["username"],
+        full_name=data.get("full_name"),
+    )
+    user.password = data["password"]
+
+    session.add(user)
+
+    subject_id = data.get("subject_id")
+    if subject_id is not None:
+        subject = session.get(Subject, subject_id)
+        if subject is None:
+            return problem(
+                status=HTTPStatus.UNPROCESSABLE_ENTITY,
+                detail="Subject not found for provided subject_id.",
+                code="subject_not_found",
+            )
+        subject.user = user
+
+    session.commit()
+    body = user_schema.dump(user)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, user)
+    response.headers["Location"] = url_for("api_v1.retrieve_user", user_id=user.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {
+            "body": body,
+            "status": HTTPStatus.CREATED,
+            "headers": headers,
+        },
+    )
+    return response
+
+
+@api_v1.patch("/users/<int:user_id>")
+@deps.require_auth
+@deps.require_scope("users:write")
+@deps.timing
+def update_user(user_id: int) -> Response:
+    """Partially update an existing user using JSON merge semantics.
+
+    :param user_id: Identifier of the user to mutate.
+    :type user_id: int
+    :returns: Updated user representation with refreshed ETag.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Fetch the requested user or produce a 404 problem response.
+    user = session.get(User, user_id)
+    if user is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="User not found.", code="not_found")
+
+    # Require an ETag to protect against lost updates.
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(user, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = user_update_schema.load(payload)
+
+    if "email" in data:
+        user.email = data["email"]
+    if "username" in data:
+        user.username = data["username"]
+    if "full_name" in data:
+        user.full_name = data["full_name"]
+    if "password" in data:
+        user.password = data["password"]
+
+    session.commit()
+    response = deps.json_response(user_schema.dump(user))
+    return set_response_etag(response, user)
+
+
+@api_v1.delete("/users/<int:user_id>")
+@deps.require_auth
+@deps.require_scope("users:write")
+@deps.timing
+def delete_user(user_id: int) -> Response:
+    """Delete a user record.
+
+    :param user_id: Identifier of the user to delete.
+    :type user_id: int
+    :returns: Empty ``204 No Content`` response on success.
+    :rtype: flask.Response
+    """
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    # Fetch the requested user or produce a 404 problem response.
+    user = session.get(User, user_id)
+    if user is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="User not found.", code="not_found")
+
+    # Require an ETag to protect against lost updates.
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(user, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(user)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)

--- a/backend/app/api/v1/workouts.py
+++ b/backend/app/api/v1/workouts.py
@@ -1,0 +1,314 @@
+"""Workout session and exercise log endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from http import HTTPStatus
+
+from flask import Response, request, url_for
+
+from app.models.exercise_log import ExerciseSetLog
+from app.models.workout import WorkoutSession
+
+from .. import deps
+from ..errors import problem
+from ..etag import set_response_etag, verify_etag
+from ..schemas import ExerciseSetLogSchema, ExerciseSetLogUpdateSchema, WorkoutSessionSchema, WorkoutSessionUpdateSchema
+from . import api_v1
+
+session_schema = WorkoutSessionSchema()
+sessions_schema = WorkoutSessionSchema(many=True)
+session_update_schema = WorkoutSessionUpdateSchema(partial=True)
+log_schema = ExerciseSetLogSchema()
+logs_schema = ExerciseSetLogSchema(many=True)
+log_update_schema = ExerciseSetLogUpdateSchema(partial=True)
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    """Parse ISO 8601 timestamps returning ``None`` when parsing fails."""
+
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+@api_v1.get("/workouts/sessions")
+@deps.timing
+def list_sessions() -> Response:
+    """List workout sessions with optional filters."""
+
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(WorkoutSession)
+
+    subject_id = request.args.get("subject_id", type=int)
+    status = request.args.get("status")
+    start_at = _parse_datetime(request.args.get("from"))
+    end_at = _parse_datetime(request.args.get("to"))
+
+    if subject_id is not None:
+        query = query.filter(WorkoutSession.subject_id == subject_id)
+    if status:
+        query = query.filter(WorkoutSession.status == status)
+    if start_at:
+        query = query.filter(WorkoutSession.workout_date >= start_at)
+    if end_at:
+        query = query.filter(WorkoutSession.workout_date <= end_at)
+
+    sort_map = {"workout_date": WorkoutSession.workout_date, "created_at": WorkoutSession.created_at}
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": sessions_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.get("/workouts/sessions/<int:session_id>")
+@deps.timing
+def retrieve_session(session_id: int) -> Response:
+    """Retrieve a workout session."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    workout = session.get(WorkoutSession, session_id)
+    if workout is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Workout session not found.", code="not_found")
+    response = deps.json_response(session_schema.dump(workout))
+    return set_response_etag(response, workout)
+
+
+@api_v1.post("/workouts/sessions")
+@deps.require_auth
+@deps.require_scope("workouts:write")
+@deps.timing
+def create_session() -> Response:
+    """Create a workout session."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = session_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    workout = WorkoutSession(**data)
+    session.add(workout)
+    session.commit()
+
+    body = session_schema.dump(workout)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, workout)
+    response.headers["Location"] = url_for("api_v1.retrieve_session", session_id=workout.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.patch("/workouts/sessions/<int:session_id>")
+@deps.require_auth
+@deps.require_scope("workouts:write")
+@deps.timing
+def update_session(session_id: int) -> Response:
+    """Patch a workout session."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    workout = session.get(WorkoutSession, session_id)
+    if workout is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Workout session not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(workout, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = session_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(workout, key, value)
+    session.commit()
+    response = deps.json_response(session_schema.dump(workout))
+    return set_response_etag(response, workout)
+
+
+@api_v1.delete("/workouts/sessions/<int:session_id>")
+@deps.require_auth
+@deps.require_scope("workouts:write")
+@deps.timing
+def delete_session(session_id: int) -> Response:
+    """Delete a workout session."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    workout = session.get(WorkoutSession, session_id)
+    if workout is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Workout session not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(workout, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(workout)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)
+
+
+@api_v1.get("/workouts/set-logs")
+@deps.timing
+def list_logs() -> Response:
+    """List exercise set logs filtered by subject, exercise, or session."""
+
+    pagination = deps.parse_pagination()
+    # Acquire a session for database work.
+    session = deps.get_session()
+    query = session.query(ExerciseSetLog)
+
+    subject_id = request.args.get("subject_id", type=int)
+    exercise_id = request.args.get("exercise_id", type=int)
+    session_id = request.args.get("session_id", type=int)
+    start_at = _parse_datetime(request.args.get("from"))
+    end_at = _parse_datetime(request.args.get("to"))
+
+    if subject_id is not None:
+        query = query.filter(ExerciseSetLog.subject_id == subject_id)
+    if exercise_id is not None:
+        query = query.filter(ExerciseSetLog.exercise_id == exercise_id)
+    if session_id is not None:
+        query = query.filter(ExerciseSetLog.session_id == session_id)
+    if start_at:
+        query = query.filter(ExerciseSetLog.performed_at >= start_at)
+    if end_at:
+        query = query.filter(ExerciseSetLog.performed_at <= end_at)
+
+    sort_map = {"performed_at": ExerciseSetLog.performed_at, "created_at": ExerciseSetLog.created_at}
+    query = deps.apply_sorting(query, sort_map, pagination.sort)
+
+    items, total = deps.paginate_query(query, pagination)
+    payload = {
+        "items": logs_schema.dump(items),
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total": total,
+    }
+    return deps.json_response(payload)
+
+
+@api_v1.get("/workouts/set-logs/<int:log_id>")
+@deps.timing
+def retrieve_log(log_id: int) -> Response:
+    """Retrieve a single exercise set log."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    log = session.get(ExerciseSetLog, log_id)
+    if log is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Exercise set log not found.", code="not_found")
+    response = deps.json_response(log_schema.dump(log))
+    return set_response_etag(response, log)
+
+
+@api_v1.post("/workouts/set-logs")
+@deps.require_auth
+@deps.require_scope("workouts:write")
+@deps.timing
+def create_log() -> Response:
+    """Create an exercise set log."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = deps.enforce_idempotency(idempotency_key)
+    if is_replay and cached is not None:
+        return deps.build_cached_response(cached)
+
+    payload = request.get_json(silent=True) or {}
+    data = log_schema.load(payload)
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    log = ExerciseSetLog(**data)
+    session.add(log)
+    session.commit()
+
+    body = log_schema.dump(log)
+    response = deps.json_response(body, status=HTTPStatus.CREATED)
+    set_response_etag(response, log)
+    response.headers["Location"] = url_for("api_v1.retrieve_log", log_id=log.id)
+    headers = {"Location": response.headers["Location"]}
+    if response.headers.get("ETag"):
+        headers["ETag"] = response.headers["ETag"]
+    deps.store_idempotent_response(
+        idempotency_key,
+        {"body": body, "status": HTTPStatus.CREATED, "headers": headers},
+    )
+    return response
+
+
+@api_v1.patch("/workouts/set-logs/<int:log_id>")
+@deps.require_auth
+@deps.require_scope("workouts:write")
+@deps.timing
+def update_log(log_id: int) -> Response:
+    """Patch an exercise set log."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    log = session.get(ExerciseSetLog, log_id)
+    if log is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Exercise set log not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(log, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    payload = request.get_json(silent=True) or {}
+    data = log_update_schema.load(payload)
+    for key, value in data.items():
+        setattr(log, key, value)
+    session.commit()
+    response = deps.json_response(log_schema.dump(log))
+    return set_response_etag(response, log)
+
+
+@api_v1.delete("/workouts/set-logs/<int:log_id>")
+@deps.require_auth
+@deps.require_scope("workouts:write")
+@deps.timing
+def delete_log(log_id: int) -> Response:
+    """Delete an exercise set log."""
+
+    # Acquire a session for database work.
+    session = deps.get_session()
+    log = session.get(ExerciseSetLog, log_id)
+    if log is None:
+        return problem(status=HTTPStatus.NOT_FOUND, detail="Exercise set log not found.", code="not_found")
+
+    if_match = request.headers.get("If-Match")
+    if not if_match:
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="Missing If-Match header.", code="missing_if_match")
+    if not verify_etag(log, if_match.strip('"')):
+        return problem(status=HTTPStatus.PRECONDITION_FAILED, detail="ETag mismatch.", code="etag_mismatch")
+
+    session.delete(log)
+    session.commit()
+    return Response(status=HTTPStatus.NO_CONTENT)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1631 @@
+openapi: 3.1.0
+info:
+  title: FitnessTrack Public API
+  version: 1.0.0
+  description: >-
+    REST API for the FitnessTrack platform. All endpoints respond with JSON and
+    leverage RFC 7807 problem-details for errors.
+servers:
+  - url: /api/v1
+    description: Version 1 base path
+security:
+  - bearerAuth: []
+tags:
+  - name: System
+  - name: Users
+  - name: Subjects
+  - name: Exercises
+  - name: Routines
+  - name: Cycles
+  - name: SubjectRoutines
+  - name: Workouts
+paths:
+  /health:
+    get:
+      tags: [System]
+      operationId: getHealth
+      summary: Readiness and liveness probe
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  db:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                  latency_ms:
+                    type: number
+                    format: float
+        '503':
+          $ref: '#/components/responses/Problem'
+  /users:
+    get:
+      tags: [Users]
+      operationId: listUsers
+      summary: List users
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+        - name: email
+          in: query
+          schema:
+            type: string
+        - name: username
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Users page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserPage'
+        '400':
+          $ref: '#/components/responses/Problem'
+    post:
+      tags: [Users]
+      operationId: createUser
+      summary: Create user
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserCreate'
+      responses:
+        '201':
+          description: Created user
+          headers:
+            Location:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '409':
+          $ref: '#/components/responses/Problem'
+        '422':
+          $ref: '#/components/responses/Problem'
+  /users/{userId}:
+    parameters:
+      - $ref: '#/components/parameters/UserId'
+    get:
+      tags: [Users]
+      operationId: getUser
+      summary: Retrieve user
+      responses:
+        '200':
+          description: User document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Users]
+      operationId: updateUser
+      summary: Update user
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdate'
+      responses:
+        '200':
+          description: Updated user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '412':
+          $ref: '#/components/responses/Problem'
+    delete:
+      tags: [Users]
+      operationId: deleteUser
+      summary: Delete user
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+        '412':
+          $ref: '#/components/responses/Problem'
+  /subjects:
+    get:
+      tags: [Subjects]
+      operationId: listSubjects
+      summary: List subjects
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+        - name: user_id
+          in: query
+          schema:
+            type: integer
+        - name: pseudonym
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Subject page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectPage'
+    post:
+      tags: [Subjects]
+      operationId: createSubject
+      summary: Create subject
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectCreate'
+      responses:
+        '201':
+          description: Created subject
+          headers:
+            Location:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subject'
+  /subjects/{subjectId}:
+    parameters:
+      - $ref: '#/components/parameters/SubjectId'
+    get:
+      tags: [Subjects]
+      operationId: getSubject
+      summary: Retrieve subject
+      responses:
+        '200':
+          description: Subject document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subject'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Subjects]
+      operationId: updateSubject
+      summary: Update subject
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectUpdate'
+      responses:
+        '200':
+          description: Updated subject
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subject'
+        '412':
+          $ref: '#/components/responses/Problem'
+    delete:
+      tags: [Subjects]
+      operationId: deleteSubject
+      summary: Delete subject
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  /subjects/{subjectId}/profile:
+    parameters:
+      - $ref: '#/components/parameters/SubjectId'
+    get:
+      tags: [Subjects]
+      operationId: getSubjectProfile
+      summary: Retrieve subject profile
+      responses:
+        '200':
+          description: Subject profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectProfile'
+        '404':
+          $ref: '#/components/responses/Problem'
+    put:
+      tags: [Subjects]
+      operationId: upsertSubjectProfile
+      summary: Replace subject profile
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectProfileUpdate'
+      responses:
+        '200':
+          description: Profile document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectProfile'
+        '412':
+          $ref: '#/components/responses/Problem'
+  /subjects/{subjectId}/body-metrics:
+    parameters:
+      - $ref: '#/components/parameters/SubjectId'
+    get:
+      tags: [Subjects]
+      operationId: listBodyMetrics
+      summary: List body metrics
+      parameters:
+        - name: measured_on
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Body metrics page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BodyMetricPage'
+    post:
+      tags: [Subjects]
+      operationId: createBodyMetric
+      summary: Create body metric
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BodyMetric'
+      responses:
+        '201':
+          description: Created metric
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BodyMetric'
+  /subjects/{subjectId}/body-metrics/{metricId}:
+    parameters:
+      - $ref: '#/components/parameters/SubjectId'
+      - name: metricId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: [Subjects]
+      operationId: getBodyMetric
+      summary: Retrieve body metric
+      responses:
+        '200':
+          description: Metric document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BodyMetric'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Subjects]
+      operationId: updateBodyMetric
+      summary: Update body metric
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BodyMetricUpdate'
+      responses:
+        '200':
+          description: Updated metric
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BodyMetric'
+    delete:
+      tags: [Subjects]
+      operationId: deleteBodyMetric
+      summary: Delete body metric
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  /exercises:
+    get:
+      tags: [Exercises]
+      operationId: listExercises
+      summary: List exercises
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+        - name: name
+          in: query
+          schema:
+            type: string
+        - name: primary_muscle
+          in: query
+          schema:
+            type: string
+        - name: equipment
+          in: query
+          schema:
+            type: string
+        - name: is_active
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Exercise page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExercisePage'
+    post:
+      tags: [Exercises]
+      operationId: createExercise
+      summary: Create exercise
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExerciseCreate'
+      responses:
+        '201':
+          description: Created exercise
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exercise'
+  /exercises/{exerciseId}:
+    parameters:
+      - name: exerciseId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: [Exercises]
+      operationId: getExercise
+      summary: Retrieve exercise
+      responses:
+        '200':
+          description: Exercise document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exercise'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Exercises]
+      operationId: updateExercise
+      summary: Update exercise
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExerciseUpdate'
+      responses:
+        '200':
+          description: Updated exercise
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exercise'
+        '412':
+          $ref: '#/components/responses/Problem'
+    delete:
+      tags: [Exercises]
+      operationId: softDeleteExercise
+      summary: Soft delete exercise
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Exercise marked inactive
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Exercise'
+  /exercises/meta/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags: [Exercises]
+      operationId: getExerciseEnum
+      summary: Get exercise reference enumeration
+      responses:
+        '200':
+          description: Enumeration values
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  values:
+                    type: array
+                    items:
+                      type: string
+        '404':
+          $ref: '#/components/responses/Problem'
+  /routines:
+    get:
+      tags: [Routines]
+      operationId: listRoutines
+      summary: List routines
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+        - name: owner_subject_id
+          in: query
+          schema:
+            type: integer
+        - name: is_public
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Routine page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoutinePage'
+    post:
+      tags: [Routines]
+      operationId: createRoutine
+      summary: Create routine
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoutineCreate'
+      responses:
+        '201':
+          description: Created routine
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Routine'
+  /routines/{routineId}:
+    parameters:
+      - $ref: '#/components/parameters/RoutineId'
+    get:
+      tags: [Routines]
+      operationId: getRoutine
+      summary: Retrieve routine
+      responses:
+        '200':
+          description: Routine document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Routine'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Routines]
+      operationId: updateRoutine
+      summary: Update routine
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoutineUpdate'
+      responses:
+        '200':
+          description: Updated routine
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Routine'
+    delete:
+      tags: [Routines]
+      operationId: deleteRoutine
+      summary: Delete routine
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  /routines/{routineId}/days:
+    parameters:
+      - $ref: '#/components/parameters/RoutineId'
+    get:
+      tags: [Routines]
+      operationId: listRoutineDays
+      summary: List routine days
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+      responses:
+        '200':
+          description: Routine days page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoutineDayPage'
+    post:
+      tags: [Routines]
+      operationId: createRoutineDay
+      summary: Create routine day
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoutineDayCreate'
+      responses:
+        '201':
+          description: Created routine day
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoutineDay'
+  /routines/{routineId}/days/{dayId}:
+    parameters:
+      - $ref: '#/components/parameters/RoutineId'
+      - name: dayId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: [Routines]
+      operationId: getRoutineDay
+      summary: Retrieve routine day
+      responses:
+        '200':
+          description: Routine day
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoutineDay'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Routines]
+      operationId: updateRoutineDay
+      summary: Update routine day
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoutineDayUpdate'
+      responses:
+        '200':
+          description: Updated day
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoutineDay'
+    delete:
+      tags: [Routines]
+      operationId: deleteRoutineDay
+      summary: Delete routine day
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  /cycles:
+    get:
+      tags: [Cycles]
+      operationId: listCycles
+      summary: List cycles
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+        - name: subject_id
+          in: query
+          schema:
+            type: integer
+        - name: routine_id
+          in: query
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Cycle page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CyclePage'
+    post:
+      tags: [Cycles]
+      operationId: createCycle
+      summary: Create cycle
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cycle'
+      responses:
+        '201':
+          description: Created cycle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cycle'
+  /cycles/{cycleId}:
+    parameters:
+      - name: cycleId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: [Cycles]
+      operationId: getCycle
+      summary: Retrieve cycle
+      responses:
+        '200':
+          description: Cycle document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cycle'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Cycles]
+      operationId: updateCycle
+      summary: Update cycle
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CycleUpdate'
+      responses:
+        '200':
+          description: Updated cycle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Cycle'
+    delete:
+      tags: [Cycles]
+      operationId: deleteCycle
+      summary: Delete cycle
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  /subject-routines:
+    get:
+      tags: [SubjectRoutines]
+      operationId: listSubjectRoutines
+      summary: List subject-routine links
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+      responses:
+        '200':
+          description: Link page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectRoutinePage'
+    post:
+      tags: [SubjectRoutines]
+      operationId: createSubjectRoutine
+      summary: Create link
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectRoutineCreate'
+      responses:
+        '201':
+          description: Created link
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectRoutine'
+  /subject-routines/{linkId}:
+    parameters:
+      - name: linkId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: [SubjectRoutines]
+      operationId: getSubjectRoutine
+      summary: Retrieve link
+      responses:
+        '200':
+          description: Link document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectRoutine'
+        '404':
+          $ref: '#/components/responses/Problem'
+    delete:
+      tags: [SubjectRoutines]
+      operationId: deleteSubjectRoutine
+      summary: Delete link
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  /workouts/sessions:
+    get:
+      tags: [Workouts]
+      operationId: listWorkoutSessions
+      summary: List workout sessions
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+      responses:
+        '200':
+          description: Session page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkoutSessionPage'
+    post:
+      tags: [Workouts]
+      operationId: createWorkoutSession
+      summary: Create workout session
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkoutSession'
+      responses:
+        '201':
+          description: Created session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkoutSession'
+  /workouts/sessions/{sessionId}:
+    parameters:
+      - name: sessionId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: [Workouts]
+      operationId: getWorkoutSession
+      summary: Retrieve workout session
+      responses:
+        '200':
+          description: Session document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkoutSession'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Workouts]
+      operationId: updateWorkoutSession
+      summary: Update workout session
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkoutSessionUpdate'
+      responses:
+        '200':
+          description: Updated session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkoutSession'
+    delete:
+      tags: [Workouts]
+      operationId: deleteWorkoutSession
+      summary: Delete workout session
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+  /workouts/set-logs:
+    get:
+      tags: [Workouts]
+      operationId: listExerciseSetLogs
+      summary: List exercise logs
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Sort'
+      responses:
+        '200':
+          description: Log page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExerciseSetLogPage'
+    post:
+      tags: [Workouts]
+      operationId: createExerciseSetLog
+      summary: Create exercise log
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExerciseSetLog'
+      responses:
+        '201':
+          description: Created log
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExerciseSetLog'
+  /workouts/set-logs/{logId}:
+    parameters:
+      - name: logId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      tags: [Workouts]
+      operationId: getExerciseSetLog
+      summary: Retrieve log
+      responses:
+        '200':
+          description: Log document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExerciseSetLog'
+        '404':
+          $ref: '#/components/responses/Problem'
+    patch:
+      tags: [Workouts]
+      operationId: updateExerciseSetLog
+      summary: Update log
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExerciseSetLogUpdate'
+      responses:
+        '200':
+          description: Updated log
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExerciseSetLog'
+    delete:
+      tags: [Workouts]
+      operationId: deleteExerciseSetLog
+      summary: Delete log
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    Page:
+      name: page
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+      description: Page number (1-indexed)
+    Limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+      description: Page size
+    Sort:
+      name: sort
+      in: query
+      schema:
+        type: string
+      description: Comma separated sort fields, prefix with '-' for descending.
+    UserId:
+      name: userId
+      in: path
+      required: true
+      schema:
+        type: integer
+    SubjectId:
+      name: subjectId
+      in: path
+      required: true
+      schema:
+        type: integer
+    RoutineId:
+      name: routineId
+      in: path
+      required: true
+      schema:
+        type: integer
+  responses:
+    Problem:
+      description: Problem details error
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+  schemas:
+    Problem:
+      type: object
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+        code:
+          type: string
+        errors:
+          oneOf:
+            - type: object
+            - type: array
+              items:
+                type: object
+    PageEnvelope:
+      type: object
+      properties:
+        items:
+          type: array
+        page:
+          type: integer
+        limit:
+          type: integer
+        total:
+          type: integer
+      required: [items, page, limit, total]
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+        username:
+          type: string
+        full_name:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required: [id, email, username]
+    UserCreate:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          required: [email, username, password]
+          properties:
+            password:
+              type: string
+              format: password
+    UserUpdate:
+      type: object
+      properties:
+        email:
+          type: string
+        username:
+          type: string
+        full_name:
+          type: string
+          nullable: true
+        password:
+          type: string
+    UserPage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/User'
+    Subject:
+      type: object
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: integer
+          nullable: true
+        pseudonym:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SubjectCreate:
+      type: object
+      properties:
+        user_id:
+          type: integer
+          nullable: true
+    SubjectUpdate:
+      type: object
+      properties:
+        user_id:
+          type: integer
+          nullable: true
+    SubjectPage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Subject'
+    SubjectProfile:
+      type: object
+      properties:
+        id:
+          type: integer
+        subject_id:
+          type: integer
+        sex:
+          type: string
+          nullable: true
+        birth_year:
+          type: integer
+          nullable: true
+        height_cm:
+          type: integer
+          nullable: true
+        dominant_hand:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SubjectProfileUpdate:
+      type: object
+      properties:
+        sex:
+          type: string
+        birth_year:
+          type: integer
+        height_cm:
+          type: integer
+        dominant_hand:
+          type: string
+    BodyMetric:
+      type: object
+      properties:
+        id:
+          type: integer
+        subject_id:
+          type: integer
+        measured_on:
+          type: string
+          format: date
+        weight_kg:
+          type: number
+          format: float
+        bodyfat_pct:
+          type: number
+          format: float
+        resting_hr:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    BodyMetricUpdate:
+      type: object
+      properties:
+        measured_on:
+          type: string
+          format: date
+        weight_kg:
+          type: number
+          format: float
+        bodyfat_pct:
+          type: number
+          format: float
+        resting_hr:
+          type: integer
+        notes:
+          type: string
+    BodyMetricPage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/BodyMetric'
+    Exercise:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        slug:
+          type: string
+        primary_muscle:
+          type: string
+        movement:
+          type: string
+        mechanics:
+          type: string
+        force:
+          type: string
+        unilateral:
+          type: boolean
+        equipment:
+          type: string
+        difficulty:
+          type: string
+        is_active:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    ExerciseCreate:
+      allOf:
+        - $ref: '#/components/schemas/Exercise'
+    ExerciseUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        slug:
+          type: string
+        primary_muscle:
+          type: string
+        movement:
+          type: string
+        mechanics:
+          type: string
+        force:
+          type: string
+        unilateral:
+          type: boolean
+        equipment:
+          type: string
+        difficulty:
+          type: string
+        is_active:
+          type: boolean
+    ExercisePage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Exercise'
+    Routine:
+      type: object
+      properties:
+        id:
+          type: integer
+        owner_subject_id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        is_public:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    RoutineCreate:
+      allOf:
+        - $ref: '#/components/schemas/Routine'
+    RoutineUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        is_public:
+          type: boolean
+    RoutinePage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Routine'
+    RoutineDay:
+      type: object
+      properties:
+        id:
+          type: integer
+        routine_id:
+          type: integer
+        day_index:
+          type: integer
+        is_rest:
+          type: boolean
+        title:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+    RoutineDayCreate:
+      allOf:
+        - $ref: '#/components/schemas/RoutineDay'
+    RoutineDayUpdate:
+      type: object
+      properties:
+        day_index:
+          type: integer
+        is_rest:
+          type: boolean
+        title:
+          type: string
+        notes:
+          type: string
+    RoutineDayPage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/RoutineDay'
+    Cycle:
+      type: object
+      properties:
+        id:
+          type: integer
+        subject_id:
+          type: integer
+        routine_id:
+          type: integer
+        cycle_number:
+          type: integer
+        started_on:
+          type: string
+          format: date
+          nullable: true
+        ended_on:
+          type: string
+          format: date
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    CycleUpdate:
+      type: object
+      properties:
+        started_on:
+          type: string
+          format: date
+        ended_on:
+          type: string
+          format: date
+        notes:
+          type: string
+    CyclePage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Cycle'
+    SubjectRoutine:
+      type: object
+      properties:
+        id:
+          type: integer
+        subject_id:
+          type: integer
+        routine_id:
+          type: integer
+        is_active:
+          type: boolean
+        saved_on:
+          type: string
+          format: date-time
+    SubjectRoutineCreate:
+      allOf:
+        - $ref: '#/components/schemas/SubjectRoutine'
+    SubjectRoutinePage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/SubjectRoutine'
+    WorkoutSession:
+      type: object
+      properties:
+        id:
+          type: integer
+        subject_id:
+          type: integer
+        workout_date:
+          type: string
+          format: date-time
+        status:
+          type: string
+        routine_day_id:
+          type: integer
+          nullable: true
+        cycle_id:
+          type: integer
+          nullable: true
+        location:
+          type: string
+          nullable: true
+        perceived_fatigue:
+          type: integer
+          nullable: true
+        bodyweight_kg:
+          type: number
+          format: float
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    WorkoutSessionUpdate:
+      type: object
+      properties:
+        workout_date:
+          type: string
+          format: date-time
+        status:
+          type: string
+        routine_day_id:
+          type: integer
+        cycle_id:
+          type: integer
+        location:
+          type: string
+        perceived_fatigue:
+          type: integer
+        bodyweight_kg:
+          type: number
+          format: float
+        notes:
+          type: string
+    WorkoutSessionPage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/WorkoutSession'
+    ExerciseSetLog:
+      type: object
+      properties:
+        id:
+          type: integer
+        subject_id:
+          type: integer
+        exercise_id:
+          type: integer
+        session_id:
+          type: integer
+          nullable: true
+        planned_set_id:
+          type: integer
+          nullable: true
+        performed_at:
+          type: string
+          format: date-time
+        set_index:
+          type: integer
+        is_warmup:
+          type: boolean
+        to_failure:
+          type: boolean
+        actual_weight_kg:
+          type: number
+          format: float
+          nullable: true
+        actual_reps:
+          type: integer
+          nullable: true
+        actual_rir:
+          type: integer
+          nullable: true
+        actual_rpe:
+          type: number
+          format: float
+          nullable: true
+        actual_tempo:
+          type: string
+          nullable: true
+        actual_rest_s:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    ExerciseSetLogUpdate:
+      type: object
+      properties:
+        exercise_id:
+          type: integer
+        session_id:
+          type: integer
+        planned_set_id:
+          type: integer
+        performed_at:
+          type: string
+          format: date-time
+        set_index:
+          type: integer
+        is_warmup:
+          type: boolean
+        to_failure:
+          type: boolean
+        actual_weight_kg:
+          type: number
+          format: float
+        actual_reps:
+          type: integer
+        actual_rir:
+          type: integer
+        actual_rpe:
+          type: number
+          format: float
+        actual_tempo:
+          type: string
+        actual_rest_s:
+          type: integer
+        notes:
+          type: string
+    ExerciseSetLogPage:
+      allOf:
+        - $ref: '#/components/schemas/PageEnvelope'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/ExerciseSetLog'

--- a/tests/api/test_smoke.py
+++ b/tests/api/test_smoke.py
@@ -1,0 +1,54 @@
+"""Smoke tests for the API blueprint wiring."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2] / 'backend'
+sys.path.insert(0, str(BACKEND_ROOT.resolve()))
+
+from app import create_app
+from app.core.extensions import db
+
+
+@pytest.fixture
+def app():
+    """Create a Flask application configured for testing."""
+
+    os.environ.setdefault("APP_ENV", "testing")
+    application = create_app()
+    with application.app_context():
+        db.create_all()
+        yield application
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    """Return a test client bound to the application."""
+
+    return app.test_client()
+
+
+def test_health_endpoint(client):
+    """Health check should return OK payload."""
+
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] in {"ok", "degraded"}
+
+
+def test_exercises_list_envelope(client):
+    """List endpoint returns pagination envelope even when empty."""
+
+    response = client.get("/api/v1/exercises?limit=1")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert set(payload.keys()) == {"items", "page", "limit", "total"}
+    assert isinstance(payload["items"], list)


### PR DESCRIPTION
## Summary
- add API endpoint map documentation covering resource relationships and rationale
- scaffold versioned Flask API blueprint with helper modules, resource handlers, and RFC 7807 errors
- publish OpenAPI 3.1 specification and smoke tests for the v1 surface

## Testing
- pytest tests/api/test_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e042c091788325868b9c54f200570b