### PR TITLE
feat: implement modular API skeleton

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,66 +1,17 @@
-"""API blueprint package aggregating versioned endpoints."""
+"""Versioned API registration helpers."""
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
-from flask import Blueprint, Flask
-
-
-def register_blueprint_group(
-    app: Flask,
-    *,
-    base_prefix: str,
-    entries: Iterable[tuple[Blueprint, str]],
-) -> None:
-    """Register related blueprints beneath a common prefix.
-
-    Parameters
-    ----------
-    app: flask.Flask
-        Application instance receiving the blueprints.
-    base_prefix: str
-        Prefix applied to all entries, typically the API version segment such
-        as ``"/api/v1"``.
-    entries: Iterable[tuple[flask.Blueprint, str]]
-        Iterable of ``(blueprint, relative_prefix)`` pairs where
-        ``relative_prefix`` is appended to ``base_prefix``.
-
-    Notes
-    -----
-    Empty relative prefixes are supported, allowing a blueprint to mount at the
-    version root while others extend it with additional path segments.
-    """
-    for bp, rel_prefix in entries:
-        # Normalize slashes safely
-        full_prefix = "/".join(
-            seg for seg in [base_prefix.rstrip("/"), rel_prefix.strip("/")] if seg
-        )
-        full_prefix = "/" + full_prefix if not full_prefix.startswith("/") else full_prefix
-        app.register_blueprint(bp, url_prefix=full_prefix)
+from flask import Flask
 
 
 def init_app(app: Flask) -> None:
-    """Register the available API versions on the Flask app.
+    """Register the available API versions on the Flask application."""
 
-    Parameters
-    ----------
-    app: flask.Flask
-        Application instance to wire with blueprints.
+    base_prefix = app.config.get("API_BASE_PREFIX", "/api").rstrip("/") or "/api"
+    from app.api.v1 import bp_v1
 
-    Notes
-    -----
-    The base prefix defaults to ``"/api"`` but can be overridden via the
-    ``API_BASE_PREFIX`` configuration key.
-    """
-    api_base = app.config.get("API_BASE_PREFIX", "/api")
+    app.register_blueprint(bp_v1, url_prefix=f"{base_prefix}/v1")
 
-    # v1
-    from app.api.v1 import API_VERSION as V1
-    from app.api.v1 import REGISTRY as V1_REGISTRY
 
-    register_blueprint_group(app, base_prefix=f"{api_base}/{V1}", entries=V1_REGISTRY)
-
-    # Future:
-    # from app.api.v2 import API_VERSION as V2, REGISTRY as V2_REGISTRY
-    # register_blueprint_group(app, base_prefix=f"{api_base}/{V2}", entries=V2_REGISTRY)
+__all__ = ["init_app"]

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,17 +1,24 @@
-"""API v1 blueprint package bundling authentication and health routes."""
+"""API v1 blueprint registration."""
 
 from __future__ import annotations
 
 from flask import Blueprint
 
-API_VERSION = "v1"
+bp_v1 = Blueprint("api_v1", __name__)
 
-# Import blueprints *only here* to keep imports localized and avoid cycles.
-from .auth import bp as auth_bp  # noqa: E402
-from .health import bp as health_bp  # noqa: E402
 
-# Each tuple: (blueprint, url_prefix_relative_to_version)
-REGISTRY: list[tuple[Blueprint, str]] = [
-    (health_bp, ""),  # -> /api/v1
-    (auth_bp, "/auth"),  # -> /api/v1/auth
-]
+def _register_blueprints() -> None:
+    from . import auth, exercises, health, routines, subjects, users, workouts
+
+    bp_v1.register_blueprint(health.bp)
+    bp_v1.register_blueprint(auth.bp)
+    bp_v1.register_blueprint(users.bp)
+    bp_v1.register_blueprint(exercises.bp)
+    bp_v1.register_blueprint(routines.bp)
+    bp_v1.register_blueprint(workouts.bp)
+    bp_v1.register_blueprint(subjects.bp)
+
+
+_register_blueprints()
+
+__all__ = ["bp_v1"]

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,115 +1,96 @@
-"""Authentication endpoints using JWT access tokens."""
+"""Authentication endpoints using the service layer."""
 
 from __future__ import annotations
 
-from flask import Blueprint, request
-from flask_jwt_extended import (
-    create_access_token,
-    get_jwt_identity,
-    jwt_required,
+from flask import Blueprint, current_app, request
+from flask_jwt_extended import get_jwt_identity
+
+from app.api.deps import (
+    build_cached_response,
+    enforce_idempotency,
+    json_response,
+    require_auth,
+    store_idempotent_response,
+    timing,
 )
+from app.api.etag import set_response_etag
+from app.core.extensions import limiter
+from app.schemas import (
+    LoginSchema,
+    RegisterSchema,
+    TokenResponseSchema,
+    UserSchema,
+    WhoAmISchema,
+)
+from app.services.auth_service import AuthService
 
-from app.core.errors import Conflict, Unauthorized
-from app.core.extensions import db
-from app.models.user import User
-from app.schemas import LoginSchema, RegisterSchema, load_data
+bp = Blueprint("auth", __name__, url_prefix="/auth")
 
-bp = Blueprint("auth", __name__)
+register_schema = RegisterSchema()
+login_schema = LoginSchema()
+user_schema = UserSchema()
+whoami_schema = WhoAmISchema()
+token_schema = TokenResponseSchema()
+
+
+def _login_rate_limit() -> str:
+    return current_app.config.get("AUTH_LOGIN_RATE_LIMIT", "5 per minute")
 
 
 @bp.post("/register")
+@timing
 def register():
-    """Register a new account and persist hashed credentials.
+    """Register a new user and return the created representation."""
 
-    Returns
-    -------
-    tuple[dict[str, int | str], int]
-        JSON payload containing the newly created user's ``id``, ``email`` and
-        ``name`` plus the ``201 Created`` status code.
-
-    Raises
-    ------
-    Conflict
-        If another user already exists with the submitted email address.
-
-    Notes
-    -----
-    - Request payload must include ``name``, ``email`` and ``password`` fields
-      that pass :class:`app.schemas.RegisterSchema` validation.
-    - Passwords are hashed via :meth:`app.models.user.User.password` before
-      persistence; no plain text storage occurs.
-    """
-    data = load_data(RegisterSchema(), request.get_json() or {})
-    name = data["name"]
-    email = data["email"]
-    password = data["password"]
-    if User.query.filter_by(email=email).first() is not None:
-        raise Conflict("Email already registered")
-
-    user = User(email=email, name=name)
-    user.password = password
-    db.session.add(user)
-    db.session.commit()
-    return {"id": user.id, "email": user.email, "name": user.name}, 201
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = enforce_idempotency(idempotency_key)
+    if is_replay and cached:
+        return build_cached_response(cached)
+    payload = register_schema.load(request.get_json(silent=True) or {})
+    service = AuthService()
+    user = service.register_user(payload)
+    body = {"data": user_schema.dump(user)}
+    response = json_response(body, status=201)
+    set_response_etag(response, user)
+    store_idempotent_response(
+        idempotency_key,
+        {
+            "body": body,
+            "status": 201,
+            "headers": {
+                "ETag": response.headers.get("ETag"),
+                "Content-Type": response.mimetype,
+            },
+        },
+    )
+    return response
 
 
 @bp.post("/login")
+@limiter.limit(_login_rate_limit)
+@timing
 def login():
-    """Authenticate credentials and issue a JWT access token.
+    """Authenticate credentials and issue an access token."""
 
-    Returns
-    -------
-    dict[str, str]
-        JSON payload with an ``access_token`` encoded by
-        :func:`flask_jwt_extended.create_access_token`.
-
-    Raises
-    ------
-    Unauthorized
-        If the email is unknown or the password verification fails.
-
-    Notes
-    -----
-    Requests are validated using :class:`app.schemas.LoginSchema`. The route
-    does not throttle attempts, so clients should implement their own retry
-    handling.
-    """
-    data = load_data(LoginSchema(), request.get_json() or {})
-    email = data["email"]
-    password = data["password"]
-
-    user = User.query.filter_by(email=email).first()
-    if user is None or not user.verify_password(password):
-        raise Unauthorized("Invalid credentials")
-
-    token = create_access_token(identity=str(user.id))
-    return {"access_token": token}
+    data = login_schema.load(request.get_json(silent=True) or {})
+    service = AuthService()
+    token, _ = service.login(data["email"], data["password"])
+    body = {"data": token_schema.dump({"access_token": token})}
+    response = json_response(body)
+    # TODO: Support idempotent login responses when backed by a shared store.
+    return response
 
 
-@bp.get("/me")
-@jwt_required()
-def me():
-    """Return the authenticated user's profile details.
+@bp.get("/whoami")
+@require_auth
+@timing
+def whoami():
+    """Return the authenticated user profile."""
 
-    Returns
-    -------
-    dict[str, int | str]
-        JSON payload exposing the current user's ``id``, ``email`` and ``name``.
-
-    Raises
-    ------
-    Unauthorized
-        If the JWT identity is missing or does not correspond to a persisted
-        user.
-
-    Notes
-    -----
-    Requires a valid ``Authorization: Bearer`` header produced by the login
-    endpoint. The handler performs a database lookup on each call and does not
-    cache results.
-    """
-    user_id = get_jwt_identity()
-    user = User.query.get(user_id)
-    if user is None:
-        raise Unauthorized("User not found")
-    return {"id": user.id, "email": user.email, "name": user.name}
+    identity = get_jwt_identity()
+    service = AuthService()
+    user = service.whoami(identity)
+    body = {"data": whoami_schema.dump(user)}
+    response = json_response(body)
+    set_response_etag(response, user)
+    return response

--- a/backend/app/api/v1/exercises.py
+++ b/backend/app/api/v1/exercises.py
@@ -1,0 +1,70 @@
+"""Exercise endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+from app.api.deps import (
+    build_cached_response,
+    enforce_idempotency,
+    json_response,
+    parse_pagination,
+    require_auth,
+    store_idempotent_response,
+    timing,
+)
+from app.api.etag import set_response_etag
+from app.schemas import ExerciseCreateSchema, ExerciseSchema, build_meta
+from app.schemas.exercise import ExerciseFilterSchema
+from app.services.exercise_service import ExerciseService
+
+bp = Blueprint("exercises", __name__, url_prefix="/exercises")
+
+exercise_schema = ExerciseSchema()
+exercise_list_schema = ExerciseSchema(many=True)
+exercise_create_schema = ExerciseCreateSchema()
+exercise_filter_schema = ExerciseFilterSchema()
+
+
+@bp.get("")
+@timing
+def list_exercises():
+    """Return paginated exercises."""
+
+    filters = exercise_filter_schema.load(request.args)
+    pagination = parse_pagination()
+    service = ExerciseService()
+    items, total = service.list_exercises(filters, pagination)
+    data = exercise_list_schema.dump(items)
+    meta = build_meta(total=total, page=pagination.page, limit=pagination.limit)
+    return json_response({"data": data, "meta": meta})
+
+
+@bp.post("")
+@require_auth
+@timing
+def create_exercise():
+    """Create a new exercise entry."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = enforce_idempotency(idempotency_key)
+    if is_replay and cached:
+        return build_cached_response(cached)
+    payload = exercise_create_schema.load(request.get_json(silent=True) or {})
+    service = ExerciseService()
+    exercise = service.create_exercise(payload)
+    body = {"data": exercise_schema.dump(exercise)}
+    response = json_response(body, status=201)
+    set_response_etag(response, exercise)
+    store_idempotent_response(
+        idempotency_key,
+        {
+            "body": body,
+            "status": 201,
+            "headers": {
+                "ETag": response.headers.get("ETag"),
+                "Content-Type": response.mimetype,
+            },
+        },
+    )
+    return response

--- a/backend/app/api/v1/routines.py
+++ b/backend/app/api/v1/routines.py
@@ -1,0 +1,71 @@
+"""Routine endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+from app.api.deps import (
+    build_cached_response,
+    enforce_idempotency,
+    json_response,
+    parse_pagination,
+    require_auth,
+    store_idempotent_response,
+    timing,
+)
+from app.api.etag import set_response_etag
+from app.schemas import RoutineCreateSchema, RoutineSchema, build_meta
+from app.schemas.routine import RoutineFilterSchema
+from app.services.routine_service import RoutineService
+
+bp = Blueprint("routines", __name__, url_prefix="/routines")
+
+routine_schema = RoutineSchema()
+routine_list_schema = RoutineSchema(many=True)
+routine_create_schema = RoutineCreateSchema()
+routine_filter_schema = RoutineFilterSchema()
+
+
+@bp.get("")
+@require_auth
+@timing
+def list_routines():
+    """Return paginated routines."""
+
+    filters = routine_filter_schema.load(request.args)
+    pagination = parse_pagination()
+    service = RoutineService()
+    items, total = service.list_routines(filters, pagination)
+    data = routine_list_schema.dump(items)
+    meta = build_meta(total=total, page=pagination.page, limit=pagination.limit)
+    return json_response({"data": data, "meta": meta})
+
+
+@bp.post("")
+@require_auth
+@timing
+def create_routine():
+    """Create a new routine."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = enforce_idempotency(idempotency_key)
+    if is_replay and cached:
+        return build_cached_response(cached)
+    payload = routine_create_schema.load(request.get_json(silent=True) or {})
+    service = RoutineService()
+    routine = service.create_routine(payload)
+    body = {"data": routine_schema.dump(routine)}
+    response = json_response(body, status=201)
+    set_response_etag(response, routine)
+    store_idempotent_response(
+        idempotency_key,
+        {
+            "body": body,
+            "status": 201,
+            "headers": {
+                "ETag": response.headers.get("ETag"),
+                "Content-Type": response.mimetype,
+            },
+        },
+    )
+    return response

--- a/backend/app/api/v1/subjects.py
+++ b/backend/app/api/v1/subjects.py
@@ -1,0 +1,71 @@
+"""Subject endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+from app.api.deps import (
+    build_cached_response,
+    enforce_idempotency,
+    json_response,
+    parse_pagination,
+    require_auth,
+    store_idempotent_response,
+    timing,
+)
+from app.api.etag import set_response_etag
+from app.schemas import SubjectCreateSchema, SubjectSchema, build_meta
+from app.schemas.subject import SubjectFilterSchema
+from app.services.subject_service import SubjectService
+
+bp = Blueprint("subjects", __name__, url_prefix="/subjects")
+
+subject_schema = SubjectSchema()
+subject_list_schema = SubjectSchema(many=True)
+subject_create_schema = SubjectCreateSchema()
+subject_filter_schema = SubjectFilterSchema()
+
+
+@bp.get("")
+@require_auth
+@timing
+def list_subjects():
+    """Return paginated subjects."""
+
+    filters = subject_filter_schema.load(request.args)
+    pagination = parse_pagination()
+    service = SubjectService()
+    items, total = service.list_subjects(filters, pagination)
+    data = subject_list_schema.dump(items)
+    meta = build_meta(total=total, page=pagination.page, limit=pagination.limit)
+    return json_response({"data": data, "meta": meta})
+
+
+@bp.post("")
+@require_auth
+@timing
+def create_subject():
+    """Create a new subject."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = enforce_idempotency(idempotency_key)
+    if is_replay and cached:
+        return build_cached_response(cached)
+    payload = subject_create_schema.load(request.get_json(silent=True) or {})
+    service = SubjectService()
+    subject = service.create_subject(payload)
+    body = {"data": subject_schema.dump(subject)}
+    response = json_response(body, status=201)
+    set_response_etag(response, subject)
+    store_idempotent_response(
+        idempotency_key,
+        {
+            "body": body,
+            "status": 201,
+            "headers": {
+                "ETag": response.headers.get("ETag"),
+                "Content-Type": response.mimetype,
+            },
+        },
+    )
+    return response

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -1,0 +1,71 @@
+"""User endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+from app.api.deps import (
+    build_cached_response,
+    enforce_idempotency,
+    json_response,
+    parse_pagination,
+    require_auth,
+    store_idempotent_response,
+    timing,
+)
+from app.api.etag import set_response_etag
+from app.schemas import UserCreateSchema, UserSchema, build_meta
+from app.schemas.user import UserFilterSchema
+from app.services.user_service import UserService
+
+bp = Blueprint("users", __name__, url_prefix="/users")
+
+user_schema = UserSchema()
+user_list_schema = UserSchema(many=True)
+user_create_schema = UserCreateSchema()
+user_filter_schema = UserFilterSchema()
+
+
+@bp.get("")
+@require_auth
+@timing
+def list_users():
+    """Return paginated users."""
+
+    filters = user_filter_schema.load(request.args)
+    pagination = parse_pagination()
+    service = UserService()
+    items, total = service.list_users(filters, pagination)
+    data = user_list_schema.dump(items)
+    meta = build_meta(total=total, page=pagination.page, limit=pagination.limit)
+    return json_response({"data": data, "meta": meta})
+
+
+@bp.post("")
+@require_auth
+@timing
+def create_user():
+    """Create a new user."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = enforce_idempotency(idempotency_key)
+    if is_replay and cached:
+        return build_cached_response(cached)
+    payload = user_create_schema.load(request.get_json(silent=True) or {})
+    service = UserService()
+    user = service.create_user(payload)
+    body = {"data": user_schema.dump(user)}
+    response = json_response(body, status=201)
+    set_response_etag(response, user)
+    store_idempotent_response(
+        idempotency_key,
+        {
+            "body": body,
+            "status": 201,
+            "headers": {
+                "ETag": response.headers.get("ETag"),
+                "Content-Type": response.mimetype,
+            },
+        },
+    )
+    return response

--- a/backend/app/api/v1/workouts.py
+++ b/backend/app/api/v1/workouts.py
@@ -1,0 +1,71 @@
+"""Workout endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+
+from app.api.deps import (
+    build_cached_response,
+    enforce_idempotency,
+    json_response,
+    parse_pagination,
+    require_auth,
+    store_idempotent_response,
+    timing,
+)
+from app.api.etag import set_response_etag
+from app.schemas import WorkoutCreateSchema, WorkoutSchema, build_meta
+from app.schemas.workout import WorkoutFilterSchema
+from app.services.workout_service import WorkoutService
+
+bp = Blueprint("workouts", __name__, url_prefix="/workouts")
+
+workout_schema = WorkoutSchema()
+workout_list_schema = WorkoutSchema(many=True)
+workout_create_schema = WorkoutCreateSchema()
+workout_filter_schema = WorkoutFilterSchema()
+
+
+@bp.get("")
+@require_auth
+@timing
+def list_workouts():
+    """Return paginated workouts."""
+
+    filters = workout_filter_schema.load(request.args)
+    pagination = parse_pagination()
+    service = WorkoutService()
+    items, total = service.list_workouts(filters, pagination)
+    data = workout_list_schema.dump(items)
+    meta = build_meta(total=total, page=pagination.page, limit=pagination.limit)
+    return json_response({"data": data, "meta": meta})
+
+
+@bp.post("")
+@require_auth
+@timing
+def create_workout():
+    """Create a new workout session."""
+
+    idempotency_key = request.headers.get("Idempotency-Key")
+    is_replay, cached = enforce_idempotency(idempotency_key)
+    if is_replay and cached:
+        return build_cached_response(cached)
+    payload = workout_create_schema.load(request.get_json(silent=True) or {})
+    service = WorkoutService()
+    workout = service.create_workout(payload)
+    body = {"data": workout_schema.dump(workout)}
+    response = json_response(body, status=201)
+    set_response_etag(response, workout)
+    store_idempotent_response(
+        idempotency_key,
+        {
+            "body": body,
+            "status": 201,
+            "headers": {
+                "ETag": response.headers.get("ETag"),
+                "Content-Type": response.mimetype,
+            },
+        },
+    )
+    return response

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,6 +38,18 @@ def env_bool(name: str, default: bool = False) -> bool:
     return str(val).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
+def env_int(name: str, default: int) -> int:
+    """Parse an integer from an environment variable."""
+
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
 class BaseConfig:
     """Base configuration shared across environments.
 
@@ -93,6 +105,16 @@ class BaseConfig:
     # Logging & CORS
     LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
     CORS_ORIGINS = os.getenv("CORS_ORIGINS", "http://localhost:5173")
+
+    # Caching & rate limiting
+    CACHE_TYPE = os.getenv("CACHE_TYPE", "SimpleCache")
+    CACHE_DEFAULT_TIMEOUT = env_int("CACHE_DEFAULT_TIMEOUT", 300)
+    RATELIMIT_DEFAULT: list[str] = []
+    AUTH_LOGIN_RATE_LIMIT = os.getenv("AUTH_LOGIN_RATE_LIMIT", "5 per minute")
+
+    # App metadata
+    APP_VERSION = os.getenv("APP_VERSION", "dev")
+    APP_COMMIT = os.getenv("APP_COMMIT", "unknown")
 
     # Built-ins de Flask
     DEBUG = False

--- a/backend/app/core/extensions.py
+++ b/backend/app/core/extensions.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 from flask import Flask
+from flask_caching import Cache
 from flask_jwt_extended import JWTManager
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import MetaData
 
-# Global naming convention for all constraints
-# Tokens útiles:
-#   %(table_name)s, %(column_0_name)s, %(referred_table_name)s, %(referred_table_name)s, etc.
-#   Para compuestas: usa _col_%(column_0_name)s_%(column_1_name)s... si quieres, o un hash.
+try:  # Optional OpenAPI support
+    from flask_smorest import Api
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    Api = None
+    api = None
+else:  # pragma: no cover - simple wiring
+    api = Api()
+
 convention = {
     "ix": "ix_%(table_name)s_%(column_0_name)s",
     "uq": "uq_%(table_name)s_%(column_0_name)s",
@@ -22,26 +29,35 @@ convention = {
 
 metadata = MetaData(naming_convention=convention)
 
-# Global singletons (import-safe)
 db: SQLAlchemy = SQLAlchemy(session_options={"autoflush": False}, metadata=metadata)
 migrate = Migrate(render_as_batch=True)
 jwt = JWTManager()
+cache = Cache()
+limiter = Limiter(key_func=get_remote_address, default_limits=[])
 
 
 def init_app(app: Flask) -> None:
-    """Initialize SQLAlchemy, migrations, and JWT extensions.
+    """Initialize extensions on the provided Flask application."""
 
-    Parameters
-    ----------
-    app: flask.Flask
-        Application used to bind extension instances. This call imports the
-        :mod:`app.models` package to ensure SQLAlchemy metadata is ready for
-        migrations.
-    """
     db.init_app(app)
-
-    # Ensure models are imported so Alembic sees metadata
-    from app import models as _models  # noqa: F401
+    from app import models  # noqa: F401 - ensure model registration
 
     migrate.init_app(app, db)
     jwt.init_app(app)
+
+    cache_config = {
+        "CACHE_TYPE": app.config.get("CACHE_TYPE", "SimpleCache"),
+        "CACHE_DEFAULT_TIMEOUT": app.config.get("CACHE_DEFAULT_TIMEOUT", 300),
+    }
+    cache.init_app(app, config=cache_config)
+
+    limiter.init_app(app)
+    limiter.default_limits = app.config.get("RATELIMIT_DEFAULT", [])
+
+    if api is not None:
+        api.init_app(app)
+    else:
+        app.logger.debug("Flask-Smorest not installed; OpenAPI generation disabled.")
+
+
+__all__ = ["db", "migrate", "jwt", "cache", "limiter", "api", "init_app"]

--- a/backend/app/core/logger.py
+++ b/backend/app/core/logger.py
@@ -1,29 +1,94 @@
-"""Logging configuration utilities for the application factory."""
+"""Structured logging configuration with request correlation."""
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from flask import Flask, g, has_request_context, request
+
+REQUEST_ID_HEADER = "X-Request-ID"
+CORRELATION_HEADERS = ("X-Request-ID", "X-Correlation-ID")
 
 
-def configure_logging(level: str = "INFO") -> None:
-    """Configure the root logger with a stdout handler.
+class JSONFormatter(logging.Formatter):
+    """Render log records as JSON objects."""
 
-    Parameters
-    ----------
-    level: str, optional
-        Logging level name such as ``"DEBUG"`` or ``"INFO"``. The value is
-        uppercased before being applied.
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting logic
+        payload: dict[str, Any] = {
+            "time": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", None),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        extra_keys = {"endpoint", "elapsed_ms"}
+        for key in extra_keys:
+            if hasattr(record, key):
+                payload[key] = getattr(record, key)
+        return json.dumps(payload, default=str)
 
-    Notes
-    -----
-    Existing root handlers are cleared before installing the new handler to
-    avoid duplicate log lines when the app factory is invoked multiple times.
-    """
+
+class RequestIdFilter(logging.Filter):
+    """Ensure a ``request_id`` attribute is always present on log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        record.request_id = ensure_request_id() if has_request_context() else None
+        return True
+
+
+def ensure_request_id() -> str:
+    """Return the current request identifier, generating one when necessary."""
+
+    if has_request_context():
+        if hasattr(g, "request_id"):
+            return g.request_id  # type: ignore[return-value]
+        for header in CORRELATION_HEADERS:
+            value = request.headers.get(header)
+            if value:
+                g.request_id = value
+                return value
+        request_id = str(uuid4())
+        g.request_id = request_id
+        return request_id
+    return str(uuid4())
+
+
+def configure_logging(level: str | int = "INFO") -> None:
+    """Configure the root logger with JSON-formatted stdout output."""
+
     handler = logging.StreamHandler(sys.stdout)
-    fmt = logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s", "%Y-%m-%dT%H:%M:%S")
-    handler.setFormatter(fmt)
+    handler.setFormatter(JSONFormatter())
+    handler.addFilter(RequestIdFilter())
     root = logging.getLogger()
     root.handlers.clear()
     root.addHandler(handler)
-    root.setLevel(level.upper())
+    level_value: int | str = level
+    if isinstance(level, str):
+        resolved = logging.getLevelName(level.upper())
+        level_value = resolved if isinstance(resolved, int) else level.upper()
+    root.setLevel(level_value)
+
+
+def init_app(app: Flask) -> None:
+    """Inject request-id middleware and attach filters to the app logger."""
+
+    app.logger.addFilter(RequestIdFilter())
+
+    @app.before_request
+    def _seed_request_id() -> None:  # pragma: no cover - integration glue
+        ensure_request_id()
+
+    @app.after_request
+    def _inject_response_header(response):  # pragma: no cover - integration glue
+        response.headers.setdefault(REQUEST_ID_HEADER, ensure_request_id())
+        return response
+
+
+__all__ = ["configure_logging", "init_app", "ensure_request_id"]

--- a/backend/app/factory.py
+++ b/backend/app/factory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from flask import Flask
 
 from app.core.config import BaseConfig, get_config
-from app.core.logger import configure_logging
+from app.core.logger import configure_logging, init_app as init_logging
 
 
 def create_app(
@@ -14,71 +14,39 @@ def create_app(
     instance_relative_config: bool = True,
     instance_config_filename: str = "config.py",
 ) -> Flask:
-    """Build and configure the Flask application.
+    """Build and configure the Flask application."""
 
-    Parameters
-    ----------
-    config: str | type[BaseConfig] | object | None, optional
-        Explicit configuration object or import string. ``None`` selects the
-        configuration from :func:`app.core.config.get_config` using
-        ``APP_ENV``.
-    instance_relative_config: bool, optional
-        Whether to resolve instance configuration files relative to
-        ``instance_path``. Defaults to ``True`` to support per-deployment
-        overrides.
-    instance_config_filename: str, optional
-        Name of the optional instance configuration file loaded via
-        :meth:`flask.Config.from_pyfile`.
-
-    Returns
-    -------
-    flask.Flask
-        Fully initialized application with extensions, CORS, proxies, API, and
-        error handlers registered.
-
-    Notes
-    -----
-    - Logging is configured eagerly so early failures are captured.
-    - The application will attempt to load ``instance_config_filename`` even
-      when ``config`` is provided unless ``instance_relative_config`` is
-      ``False``.
-    """
     app = Flask(__name__, instance_relative_config=instance_relative_config)
 
-    # Config
     app.config.from_object(get_config() if config is None else config)
     if instance_relative_config and instance_config_filename:
         app.config.from_pyfile(instance_config_filename, silent=True)
 
-    # Logging ASAP
     configure_logging(app.config.get("LOG_LEVEL", "INFO"))
 
-    # Proxy (opcional si externalizas)
+    # Proxy headers if running behind a reverse proxy (optional module)
     from app.core import proxy
 
     proxy.init_app(app)
 
-    # Extensiones
     from app.core import extensions
 
     extensions.init_app(app)
 
-    # CORS
+    init_logging(app)
+
     from app.core import cors
 
     cors.init_app(app)
 
-    # API
-    from app import api
+    from app.api import init_app as init_api
 
-    api.init_app(app)
+    init_api(app)
 
-    # Errores
     from app.core import errors
 
     errors.init_app(app)
 
-    # Shell/CLI
     from app import cli as app_cli
 
     app_cli.init_app(app)

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,17 @@
+"""Repository layer aggregating data-access helpers."""
+
+from __future__ import annotations
+
+from .exercise_repo import ExerciseRepository
+from .routine_repo import RoutineRepository
+from .subject_repo import SubjectRepository
+from .user_repo import UserRepository
+from .workout_repo import WorkoutRepository
+
+__all__ = [
+    "ExerciseRepository",
+    "RoutineRepository",
+    "SubjectRepository",
+    "UserRepository",
+    "WorkoutRepository",
+]

--- a/backend/app/repositories/exercise_repo.py
+++ b/backend/app/repositories/exercise_repo.py
@@ -1,0 +1,105 @@
+"""Repository utilities for the ``Exercise`` model."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from app.models.exercise import Exercise
+
+
+class ExerciseRepository:
+    """Encapsulate frequently used ``Exercise`` queries."""
+
+    sort_fields = {
+        "created_at": Exercise.created_at,
+        "updated_at": Exercise.updated_at,
+        "name": Exercise.name,
+        "slug": Exercise.slug,
+    }
+
+    def base_select(self) -> Select[Any]:
+        """Return the base select for exercises."""
+
+        return select(Exercise)
+
+    def apply_filters(self, statement: Select[Any], filters: Mapping[str, Any]) -> Select[Any]:
+        """Apply filter mapping to the select statement."""
+
+        name = filters.get("name")
+        if name:
+            statement = statement.where(Exercise.name.ilike(f"%{name}%"))
+        primary_muscle = filters.get("primary_muscle")
+        if primary_muscle:
+            statement = statement.where(Exercise.primary_muscle == primary_muscle)
+        equipment = filters.get("equipment")
+        if equipment:
+            statement = statement.where(Exercise.equipment == equipment)
+        is_active = filters.get("is_active")
+        if is_active is not None:
+            statement = statement.where(Exercise.is_active == bool(is_active))
+        return statement
+
+    def apply_sort(self, statement: Select[Any], tokens: Sequence[str]) -> Select[Any]:
+        """Apply sorting instructions to the statement."""
+
+        orders: list[Any] = []
+        for token in tokens:
+            desc = token.startswith("-")
+            key = token[1:] if desc else token
+            column = self.sort_fields.get(key)
+            if column is None:
+                continue
+            orders.append(column.desc() if desc else column.asc())
+        if orders:
+            statement = statement.order_by(*orders)
+        return statement
+
+    def paginate(
+        self, session: Session, statement: Select[Any], *, page: int, limit: int
+    ) -> tuple[list[Exercise], int]:
+        """Execute the select and return paginated exercise records."""
+
+        page = max(page, 1)
+        limit = max(limit, 1)
+        count_stmt = select(func.count()).select_from(statement.order_by(None).subquery())
+        total = session.execute(count_stmt).scalar_one_or_none() or 0
+        offset = (page - 1) * limit
+        result = session.execute(statement.limit(limit).offset(offset))
+        return list(result.scalars()), int(total)
+
+    def query(
+        self,
+        session: Session,
+        filters: Mapping[str, Any],
+        *,
+        page: int,
+        limit: int,
+        sort: Sequence[str],
+    ) -> tuple[list[Exercise], int]:
+        """Return filtered and paginated exercises."""
+
+        statement = self.apply_filters(self.base_select(), filters)
+        statement = self.apply_sort(statement, sort)
+        return self.paginate(session, statement, page=page, limit=limit)
+
+    def create(self, session: Session, data: Mapping[str, Any]) -> Exercise:
+        """Persist a new exercise entity."""
+
+        exercise = Exercise(
+            name=data["name"],
+            slug=data["slug"],
+            primary_muscle=data["primary_muscle"],
+            movement=data["movement"],
+            mechanics=data["mechanics"],
+            force=data["force"],
+            equipment=data["equipment"],
+            difficulty=data.get("difficulty", "BEGINNER"),
+            is_active=data.get("is_active", True),
+            cues=data.get("cues"),
+            instructions=data.get("instructions"),
+        )
+        session.add(exercise)
+        return exercise

--- a/backend/app/repositories/routine_repo.py
+++ b/backend/app/repositories/routine_repo.py
@@ -1,0 +1,94 @@
+"""Repository utilities for the ``Routine`` model."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from app.models.routine import Routine
+
+
+class RoutineRepository:
+    """Encapsulate data-access patterns for routines."""
+
+    sort_fields = {
+        "created_at": Routine.created_at,
+        "updated_at": Routine.updated_at,
+        "name": Routine.name,
+    }
+
+    def base_select(self) -> Select[Any]:
+        """Return the base select for routines."""
+
+        return select(Routine)
+
+    def apply_filters(self, statement: Select[Any], filters: Mapping[str, Any]) -> Select[Any]:
+        """Apply filter mapping to the select statement."""
+
+        owner_subject_id = filters.get("owner_subject_id")
+        if owner_subject_id is not None:
+            statement = statement.where(Routine.owner_subject_id == owner_subject_id)
+        is_public = filters.get("is_public")
+        if is_public is not None:
+            statement = statement.where(Routine.is_public == bool(is_public))
+        name = filters.get("name")
+        if name:
+            statement = statement.where(Routine.name.ilike(f"%{name}%"))
+        return statement
+
+    def apply_sort(self, statement: Select[Any], tokens: Sequence[str]) -> Select[Any]:
+        """Apply sorting instructions to the statement."""
+
+        orders: list[Any] = []
+        for token in tokens:
+            desc = token.startswith("-")
+            key = token[1:] if desc else token
+            column = self.sort_fields.get(key)
+            if column is None:
+                continue
+            orders.append(column.desc() if desc else column.asc())
+        if orders:
+            statement = statement.order_by(*orders)
+        return statement
+
+    def paginate(
+        self, session: Session, statement: Select[Any], *, page: int, limit: int
+    ) -> tuple[list[Routine], int]:
+        """Execute the select and return paginated routines."""
+
+        page = max(page, 1)
+        limit = max(limit, 1)
+        count_stmt = select(func.count()).select_from(statement.order_by(None).subquery())
+        total = session.execute(count_stmt).scalar_one_or_none() or 0
+        offset = (page - 1) * limit
+        result = session.execute(statement.limit(limit).offset(offset))
+        return list(result.scalars()), int(total)
+
+    def query(
+        self,
+        session: Session,
+        filters: Mapping[str, Any],
+        *,
+        page: int,
+        limit: int,
+        sort: Sequence[str],
+    ) -> tuple[list[Routine], int]:
+        """Return filtered and paginated routine rows."""
+
+        statement = self.apply_filters(self.base_select(), filters)
+        statement = self.apply_sort(statement, sort)
+        return self.paginate(session, statement, page=page, limit=limit)
+
+    def create(self, session: Session, data: Mapping[str, Any]) -> Routine:
+        """Persist a new routine record."""
+
+        routine = Routine(
+            owner_subject_id=data["owner_subject_id"],
+            name=data["name"],
+            description=data.get("description"),
+            is_public=data.get("is_public", False),
+        )
+        session.add(routine)
+        return routine

--- a/backend/app/repositories/subject_repo.py
+++ b/backend/app/repositories/subject_repo.py
@@ -1,0 +1,83 @@
+"""Repository utilities for the ``Subject`` model."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from app.models.subject import Subject
+
+
+class SubjectRepository:
+    """Encapsulate database access patterns for subjects."""
+
+    sort_fields = {
+        "created_at": Subject.created_at,
+        "updated_at": Subject.updated_at,
+        "id": Subject.id,
+    }
+
+    def base_select(self) -> Select[Any]:
+        """Return the base select for subjects."""
+
+        return select(Subject)
+
+    def apply_filters(self, statement: Select[Any], filters: Mapping[str, Any]) -> Select[Any]:
+        """Apply filter mapping to the select statement."""
+
+        user_id = filters.get("user_id")
+        if user_id is not None:
+            statement = statement.where(Subject.user_id == user_id)
+        return statement
+
+    def apply_sort(self, statement: Select[Any], tokens: Sequence[str]) -> Select[Any]:
+        """Apply sorting instructions to the statement."""
+
+        orders: list[Any] = []
+        for token in tokens:
+            desc = token.startswith("-")
+            key = token[1:] if desc else token
+            column = self.sort_fields.get(key)
+            if column is None:
+                continue
+            orders.append(column.desc() if desc else column.asc())
+        if orders:
+            statement = statement.order_by(*orders)
+        return statement
+
+    def paginate(
+        self, session: Session, statement: Select[Any], *, page: int, limit: int
+    ) -> tuple[list[Subject], int]:
+        """Execute the select and return paginated subjects."""
+
+        page = max(page, 1)
+        limit = max(limit, 1)
+        count_stmt = select(func.count()).select_from(statement.order_by(None).subquery())
+        total = session.execute(count_stmt).scalar_one_or_none() or 0
+        offset = (page - 1) * limit
+        result = session.execute(statement.limit(limit).offset(offset))
+        return list(result.scalars()), int(total)
+
+    def query(
+        self,
+        session: Session,
+        filters: Mapping[str, Any],
+        *,
+        page: int,
+        limit: int,
+        sort: Sequence[str],
+    ) -> tuple[list[Subject], int]:
+        """Return filtered and paginated subjects."""
+
+        statement = self.apply_filters(self.base_select(), filters)
+        statement = self.apply_sort(statement, sort)
+        return self.paginate(session, statement, page=page, limit=limit)
+
+    def create(self, session: Session, data: Mapping[str, Any]) -> Subject:
+        """Persist a new subject."""
+
+        subject = Subject(user_id=data.get("user_id"))
+        session.add(subject)
+        return subject

--- a/backend/app/repositories/user_repo.py
+++ b/backend/app/repositories/user_repo.py
@@ -1,0 +1,106 @@
+"""Repository utilities for the ``User`` model."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+
+
+class UserRepository:
+    """Encapsulate common ``User`` queries."""
+
+    sort_fields = {
+        "created_at": User.created_at,
+        "updated_at": User.updated_at,
+        "username": User.username,
+        "email": User.email,
+    }
+
+    def base_select(self) -> Select[Any]:
+        """Return the base select for the ``users`` table."""
+
+        return select(User)
+
+    def apply_filters(self, statement: Select[Any], filters: Mapping[str, Any]) -> Select[Any]:
+        """Apply filtering criteria based on provided mapping."""
+
+        email = filters.get("email")
+        if email:
+            statement = statement.where(func.lower(User.email).like(f"%{email.lower()}%"))
+        username = filters.get("username")
+        if username:
+            statement = statement.where(User.username.ilike(f"%{username}%"))
+        return statement
+
+    def apply_sort(self, statement: Select[Any], tokens: Sequence[str]) -> Select[Any]:
+        """Apply client-supplied sort tokens to the statement."""
+
+        orders: list[Any] = []
+        for token in tokens:
+            desc = token.startswith("-")
+            key = token[1:] if desc else token
+            column = self.sort_fields.get(key)
+            if column is None:
+                continue
+            orders.append(column.desc() if desc else column.asc())
+        if orders:
+            statement = statement.order_by(*orders)
+        return statement
+
+    def paginate(
+        self, session: Session, statement: Select[Any], *, page: int, limit: int
+    ) -> tuple[list[User], int]:
+        """Execute the select with pagination returning domain objects."""
+
+        page = max(page, 1)
+        limit = max(limit, 1)
+        count_stmt = select(func.count()).select_from(statement.order_by(None).subquery())
+        total = session.execute(count_stmt).scalar_one_or_none() or 0
+        offset = (page - 1) * limit
+        result = session.execute(statement.limit(limit).offset(offset))
+        return list(result.scalars()), int(total)
+
+    def query(
+        self,
+        session: Session,
+        filters: Mapping[str, Any],
+        *,
+        page: int,
+        limit: int,
+        sort: Sequence[str],
+    ) -> tuple[list[User], int]:
+        """Return a paginated list of users matching filters."""
+
+        statement = self.apply_filters(self.base_select(), filters)
+        statement = self.apply_sort(statement, sort)
+        return self.paginate(session, statement, page=page, limit=limit)
+
+    def create(self, session: Session, data: Mapping[str, Any]) -> User:
+        """Instantiate and persist a ``User`` instance."""
+
+        user = User(
+            email=data["email"],
+            username=data["username"],
+            full_name=data.get("full_name"),
+        )
+        password = data.get("password")
+        if password:
+            user.password = password  # type: ignore[assignment]
+        session.add(user)
+        return user
+
+    def get_by_email(self, session: Session, email: str) -> User | None:
+        """Return a user by normalized email if present."""
+
+        stmt = select(User).where(func.lower(User.email) == email.strip().lower())
+        return session.execute(stmt).scalar_one_or_none()
+
+    def get_by_id(self, session: Session, user_id: int) -> User | None:
+        """Return a user by identifier."""
+
+        stmt = select(User).where(User.id == user_id)
+        return session.execute(stmt).scalar_one_or_none()

--- a/backend/app/repositories/workout_repo.py
+++ b/backend/app/repositories/workout_repo.py
@@ -1,0 +1,102 @@
+"""Repository utilities for the ``WorkoutSession`` model."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from app.models.workout import WorkoutSession
+
+
+class WorkoutRepository:
+    """Encapsulate database access for workout sessions."""
+
+    sort_fields = {
+        "workout_date": WorkoutSession.workout_date,
+        "created_at": WorkoutSession.created_at,
+        "updated_at": WorkoutSession.updated_at,
+    }
+
+    def base_select(self) -> Select[Any]:
+        """Return the base select for workout sessions."""
+
+        return select(WorkoutSession)
+
+    def apply_filters(self, statement: Select[Any], filters: Mapping[str, Any]) -> Select[Any]:
+        """Apply filter mapping to the select statement."""
+
+        subject_id = filters.get("subject_id")
+        if subject_id is not None:
+            statement = statement.where(WorkoutSession.subject_id == subject_id)
+        status = filters.get("status")
+        if status:
+            statement = statement.where(WorkoutSession.status == status)
+        date_from = filters.get("date_from")
+        if date_from is not None:
+            statement = statement.where(WorkoutSession.workout_date >= date_from)
+        date_to = filters.get("date_to")
+        if date_to is not None:
+            statement = statement.where(WorkoutSession.workout_date <= date_to)
+        return statement
+
+    def apply_sort(self, statement: Select[Any], tokens: Sequence[str]) -> Select[Any]:
+        """Apply sorting instructions to the statement."""
+
+        orders: list[Any] = []
+        for token in tokens:
+            desc = token.startswith("-")
+            key = token[1:] if desc else token
+            column = self.sort_fields.get(key)
+            if column is None:
+                continue
+            orders.append(column.desc() if desc else column.asc())
+        if orders:
+            statement = statement.order_by(*orders)
+        return statement
+
+    def paginate(
+        self, session: Session, statement: Select[Any], *, page: int, limit: int
+    ) -> tuple[list[WorkoutSession], int]:
+        """Execute the select and return paginated workouts."""
+
+        page = max(page, 1)
+        limit = max(limit, 1)
+        count_stmt = select(func.count()).select_from(statement.order_by(None).subquery())
+        total = session.execute(count_stmt).scalar_one_or_none() or 0
+        offset = (page - 1) * limit
+        result = session.execute(statement.limit(limit).offset(offset))
+        return list(result.scalars()), int(total)
+
+    def query(
+        self,
+        session: Session,
+        filters: Mapping[str, Any],
+        *,
+        page: int,
+        limit: int,
+        sort: Sequence[str],
+    ) -> tuple[list[WorkoutSession], int]:
+        """Return filtered and paginated workout sessions."""
+
+        statement = self.apply_filters(self.base_select(), filters)
+        statement = self.apply_sort(statement, sort)
+        return self.paginate(session, statement, page=page, limit=limit)
+
+    def create(self, session: Session, data: Mapping[str, Any]) -> WorkoutSession:
+        """Persist a new workout session."""
+
+        workout = WorkoutSession(
+            subject_id=data["subject_id"],
+            workout_date=data["workout_date"],
+            status=data.get("status", "PENDING"),
+            routine_day_id=data.get("routine_day_id"),
+            cycle_id=data.get("cycle_id"),
+            location=data.get("location"),
+            perceived_fatigue=data.get("perceived_fatigue"),
+            bodyweight_kg=data.get("bodyweight_kg"),
+            notes=data.get("notes"),
+        )
+        session.add(workout)
+        return workout

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,43 +1,32 @@
-"""Schema utilities centralizing Marshmallow helpers and exports."""
+"""Convenience exports for application schemas."""
 
 from __future__ import annotations
 
-from typing import Any, cast
+from .auth import LoginSchema, RegisterSchema, TokenResponseSchema, WhoAmISchema
+from .common import MetaSchema, PaginationQuerySchema, SortQuerySchema, build_meta
+from .exercise import ExerciseCreateSchema, ExerciseSchema
+from .routine import RoutineCreateSchema, RoutineSchema
+from .subject import SubjectCreateSchema, SubjectSchema
+from .user import UserCreateSchema, UserSchema
+from .workout import WorkoutCreateSchema, WorkoutSchema
 
-from marshmallow import Schema, ValidationError
-
-from app.core.errors import APIError
-
-
-def load_data(schema: Schema, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate a payload using the provided schema and return the result.
-
-    Parameters
-    ----------
-    schema: marshmallow.Schema
-        Schema instance used to deserialize and validate the payload.
-    data: dict[str, Any]
-        Raw request payload typically obtained from ``request.get_json``.
-
-    Returns
-    -------
-    dict[str, Any]
-        Deserialized payload produced by ``schema.load``.
-
-    Raises
-    ------
-    APIError
-        If validation fails. Field-level errors are included in ``details``.
-    """
-    try:
-        return cast(dict[str, Any], schema.load(data))
-    except ValidationError as err:  # pragma: no cover - simple pass-through
-        raise APIError(
-            "Invalid payload",
-            status_code=400,
-            code="validation_error",
-            details=err.messages,
-        ) from err
-
-
-from .auth import LoginSchema, RegisterSchema  # noqa: E402,F401
+__all__ = [
+    "LoginSchema",
+    "RegisterSchema",
+    "TokenResponseSchema",
+    "WhoAmISchema",
+    "PaginationQuerySchema",
+    "SortQuerySchema",
+    "MetaSchema",
+    "build_meta",
+    "ExerciseSchema",
+    "ExerciseCreateSchema",
+    "RoutineSchema",
+    "RoutineCreateSchema",
+    "SubjectSchema",
+    "SubjectCreateSchema",
+    "UserSchema",
+    "UserCreateSchema",
+    "WorkoutSchema",
+    "WorkoutCreateSchema",
+]

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,4 +1,4 @@
-"""Marshmallow schemas backing authentication endpoints."""
+"""Authentication-related Marshmallow schemas."""
 
 from __future__ import annotations
 
@@ -6,18 +6,32 @@ from marshmallow import Schema, fields, validate
 
 
 class RegisterSchema(Schema):
-    """Validate incoming registration payloads."""
+    """Input payload for account registration."""
 
-    name = fields.String(
-        required=True,
-        validate=validate.Length(min=1, max=120),
-    )
-    email = fields.Email(required=True)
-    password = fields.String(required=True, validate=validate.Length(min=8))
+    email = fields.Email(required=True, validate=validate.Length(max=254))
+    username = fields.String(required=True, validate=validate.Length(min=3, max=50))
+    password = fields.String(required=True, validate=validate.Length(min=8, max=128))
+    full_name = fields.String(load_default=None, validate=validate.Length(max=100))
 
 
 class LoginSchema(Schema):
-    """Validate incoming login payloads."""
+    """Input payload for authenticating a user."""
 
+    email = fields.Email(required=True, validate=validate.Length(max=254))
+    password = fields.String(required=True, validate=validate.Length(min=8, max=128))
+
+
+class TokenResponseSchema(Schema):
+    """Response payload containing an access token."""
+
+    access_token = fields.String(required=True)
+    token_type = fields.String(load_default="bearer")
+
+
+class WhoAmISchema(Schema):
+    """Response payload exposing identity details for the authenticated user."""
+
+    id = fields.Integer(required=True)
     email = fields.Email(required=True)
-    password = fields.String(required=True)
+    username = fields.String(required=True)
+    full_name = fields.String(allow_none=True)

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -1,0 +1,59 @@
+"""Common Marshmallow schemas shared across resources."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from marshmallow import Schema, fields, post_load, validate
+
+
+class SortQuerySchema(Schema):
+    """Parse comma-separated ``sort`` query parameters into a list."""
+
+    sort = fields.String(load_default="")
+
+    @post_load
+    def split_sort(self, data: dict[str, Any], **_: Any) -> dict[str, Any]:
+        raw = data.get("sort") or ""
+        tokens = [segment.strip() for segment in raw.split(",") if segment.strip()]
+        data["sort"] = tokens
+        return data
+
+
+class PaginationQuerySchema(SortQuerySchema):
+    """Validate pagination parameters with configurable defaults."""
+
+    def __init__(self, *, default_limit: int = 20, max_limit: int = 200, **kwargs: Any) -> None:
+        self._default_limit = default_limit
+        self._max_limit = max_limit
+        super().__init__(**kwargs)
+
+    page = fields.Integer(load_default=1, validate=validate.Range(min=1))
+    limit = fields.Integer(validate=validate.Range(min=1))
+
+    @post_load
+    def apply_defaults(self, data: dict[str, Any], **_: Any) -> dict[str, Any]:
+        sort_value = data.get("sort")
+        if isinstance(sort_value, str):
+            tokens = [segment.strip() for segment in sort_value.split(",") if segment.strip()]
+            data["sort"] = tokens
+        elif sort_value is None:
+            data["sort"] = []
+        limit = data.get("limit", self._default_limit)
+        data["limit"] = min(max(limit, 1), self._max_limit)
+        data.setdefault("page", 1)
+        return data
+
+
+class MetaSchema(Schema):
+    """Metadata block for paginated responses."""
+
+    total = fields.Integer(required=True)
+    page = fields.Integer(required=True)
+    limit = fields.Integer(required=True)
+
+
+def build_meta(*, total: int, page: int, limit: int) -> dict[str, int]:
+    """Return a ``meta`` mapping for paginated responses."""
+
+    return {"total": int(total), "page": int(page), "limit": int(limit)}

--- a/backend/app/schemas/exercise.py
+++ b/backend/app/schemas/exercise.py
@@ -1,0 +1,50 @@
+"""Exercise resource schemas."""
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema, fields, validate
+
+
+class ExerciseCreateSchema(Schema):
+    """Payload for creating a new exercise."""
+
+    name = fields.String(required=True, validate=validate.Length(min=3, max=120))
+    slug = fields.String(required=True, validate=validate.Length(min=3, max=140))
+    primary_muscle = fields.String(required=True)
+    movement = fields.String(required=True)
+    mechanics = fields.String(required=True)
+    force = fields.String(required=True)
+    equipment = fields.String(required=True)
+    difficulty = fields.String(load_default="BEGINNER")
+    is_active = fields.Boolean(load_default=True)
+    cues = fields.String(load_default=None)
+    instructions = fields.String(load_default=None)
+
+
+class ExerciseFilterSchema(Schema):
+    """Supported query parameters when listing exercises."""
+
+    class Meta:
+        unknown = EXCLUDE
+
+    name = fields.String(load_default=None, validate=validate.Length(min=1, max=120))
+    primary_muscle = fields.String(load_default=None)
+    equipment = fields.String(load_default=None)
+    is_active = fields.Boolean(load_default=None)
+
+
+class ExerciseSchema(Schema):
+    """Representation of the exercise entity."""
+
+    id = fields.Integer(required=True)
+    name = fields.String(required=True)
+    slug = fields.String(required=True)
+    primary_muscle = fields.String(required=True)
+    movement = fields.String(required=True)
+    mechanics = fields.String(required=True)
+    force = fields.String(required=True)
+    equipment = fields.String(required=True)
+    difficulty = fields.String(required=True)
+    is_active = fields.Boolean(required=True)
+    created_at = fields.DateTime(required=True)
+    updated_at = fields.DateTime(required=True)

--- a/backend/app/schemas/routine.py
+++ b/backend/app/schemas/routine.py
@@ -1,0 +1,37 @@
+"""Routine resource schemas."""
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema, fields, validate
+
+
+class RoutineCreateSchema(Schema):
+    """Payload for creating a new routine."""
+
+    owner_subject_id = fields.Integer(required=True)
+    name = fields.String(required=True, validate=validate.Length(min=3, max=120))
+    description = fields.String(load_default=None)
+    is_public = fields.Boolean(load_default=False)
+
+
+class RoutineFilterSchema(Schema):
+    """Query parameters accepted by the routines list endpoint."""
+
+    class Meta:
+        unknown = EXCLUDE
+
+    owner_subject_id = fields.Integer(load_default=None)
+    is_public = fields.Boolean(load_default=None)
+    name = fields.String(load_default=None, validate=validate.Length(min=1, max=120))
+
+
+class RoutineSchema(Schema):
+    """Representation of the routine entity."""
+
+    id = fields.Integer(required=True)
+    owner_subject_id = fields.Integer(required=True)
+    name = fields.String(required=True)
+    description = fields.String(allow_none=True)
+    is_public = fields.Boolean(required=True)
+    created_at = fields.DateTime(required=True)
+    updated_at = fields.DateTime(required=True)

--- a/backend/app/schemas/subject.py
+++ b/backend/app/schemas/subject.py
@@ -1,0 +1,30 @@
+"""Subject resource schemas."""
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema, fields
+
+
+class SubjectCreateSchema(Schema):
+    """Payload for creating a subject entity."""
+
+    user_id = fields.Integer(load_default=None)
+
+
+class SubjectFilterSchema(Schema):
+    """Query parameters accepted by the subjects list endpoint."""
+
+    class Meta:
+        unknown = EXCLUDE
+
+    user_id = fields.Integer(load_default=None)
+
+
+class SubjectSchema(Schema):
+    """Representation of the pseudonymous subject entity."""
+
+    id = fields.Integer(required=True)
+    user_id = fields.Integer(allow_none=True)
+    pseudonym = fields.UUID(required=True)
+    created_at = fields.DateTime(required=True)
+    updated_at = fields.DateTime(required=True)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,35 @@
+"""User resource schemas."""
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema, fields, validate
+
+
+class UserCreateSchema(Schema):
+    """Payload for creating a new user from the admin surface."""
+
+    email = fields.Email(required=True, validate=validate.Length(max=254))
+    username = fields.String(required=True, validate=validate.Length(min=3, max=50))
+    password = fields.String(required=True, validate=validate.Length(min=8, max=128))
+    full_name = fields.String(load_default=None, validate=validate.Length(max=100))
+
+
+class UserFilterSchema(Schema):
+    """Supported query parameters for listing users."""
+
+    class Meta:
+        unknown = EXCLUDE
+
+    email = fields.String(load_default=None, validate=validate.Length(min=1, max=254))
+    username = fields.String(load_default=None, validate=validate.Length(min=1, max=50))
+
+
+class UserSchema(Schema):
+    """Public representation of a user entity."""
+
+    id = fields.Integer(required=True)
+    email = fields.Email(required=True)
+    username = fields.String(required=True)
+    full_name = fields.String(allow_none=True)
+    created_at = fields.DateTime(required=True)
+    updated_at = fields.DateTime(required=True)

--- a/backend/app/schemas/workout.py
+++ b/backend/app/schemas/workout.py
@@ -1,0 +1,48 @@
+"""Workout resource schemas."""
+
+from __future__ import annotations
+
+from marshmallow import EXCLUDE, Schema, fields, validate
+
+
+class WorkoutCreateSchema(Schema):
+    """Payload for creating a workout session."""
+
+    subject_id = fields.Integer(required=True)
+    workout_date = fields.DateTime(required=True)
+    status = fields.String(load_default="PENDING")
+    routine_day_id = fields.Integer(load_default=None)
+    cycle_id = fields.Integer(load_default=None)
+    location = fields.String(load_default=None, validate=validate.Length(max=120))
+    perceived_fatigue = fields.Integer(load_default=None)
+    bodyweight_kg = fields.Float(load_default=None)
+    notes = fields.String(load_default=None)
+
+
+class WorkoutFilterSchema(Schema):
+    """Query parameters accepted by the workouts list endpoint."""
+
+    class Meta:
+        unknown = EXCLUDE
+
+    subject_id = fields.Integer(load_default=None)
+    status = fields.String(load_default=None)
+    date_from = fields.DateTime(load_default=None)
+    date_to = fields.DateTime(load_default=None)
+
+
+class WorkoutSchema(Schema):
+    """Representation of the workout session entity."""
+
+    id = fields.Integer(required=True)
+    subject_id = fields.Integer(required=True)
+    workout_date = fields.DateTime(required=True)
+    status = fields.String(required=True)
+    routine_day_id = fields.Integer(allow_none=True)
+    cycle_id = fields.Integer(allow_none=True)
+    location = fields.String(allow_none=True)
+    perceived_fatigue = fields.Integer(allow_none=True)
+    bodyweight_kg = fields.Float(allow_none=True)
+    notes = fields.String(allow_none=True)
+    created_at = fields.DateTime(required=True)
+    updated_at = fields.DateTime(required=True)

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,16 @@
+"""Service layer helpers."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.core.extensions import db
+
+
+def get_session(session: Session | None = None) -> Session:
+    """Return the provided SQLAlchemy session or fall back to the global session."""
+
+    return session or db.session
+
+
+__all__ = ["get_session"]

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,67 @@
+"""Authentication domain services."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from flask_jwt_extended import create_access_token
+from sqlalchemy.exc import IntegrityError
+
+from app.core.errors import Conflict, Unauthorized
+from app.repositories import UserRepository
+
+from . import get_session
+
+
+class AuthService:
+    """Coordinate registration and authentication operations."""
+
+    def __init__(self, session=None) -> None:
+        self.session = get_session(session)
+        self.users = UserRepository()
+
+    def register_user(self, data: Mapping[str, object]):
+        """Register a new user and return the persisted entity."""
+
+        try:
+            user = self.users.create(self.session, data)
+            # TODO: Integrate password hashing/pepper strategy before persistence.
+            self.session.commit()
+        except IntegrityError as exc:  # pragma: no cover - depends on DB backend
+            self.session.rollback()
+            raise Conflict("User already exists") from exc
+        return user
+
+    def authenticate(self, email: str, password: str):
+        """Validate credentials and return the matching user."""
+
+        user = self.users.get_by_email(self.session, email)
+        if user is None or not user.verify_password(password):
+            raise Unauthorized("Invalid credentials")
+        return user
+
+    def issue_access_token(self, user) -> str:
+        """Issue a short-lived JWT access token for the given user."""
+
+        identity = str(user.id)
+        # TODO: Add refresh tokens, roles, and fine-grained scope claims.
+        return create_access_token(identity=identity, additional_claims={"scopes": ["user:read"]})
+
+    def login(self, email: str, password: str) -> tuple[str, object]:
+        """Authenticate credentials and return ``(token, user)``."""
+
+        user = self.authenticate(email, password)
+        token = self.issue_access_token(user)
+        return token, user
+
+    def whoami(self, identity: str | int):
+        """Return the user referenced by the JWT identity."""
+
+        try:
+            user_id = int(identity)
+        except (TypeError, ValueError):  # pragma: no cover - defensive guard
+            raise Unauthorized("Invalid token subject") from None
+        user = self.users.get_by_id(self.session, user_id)
+        if user is None:
+            raise Unauthorized("User not found")
+        return user

--- a/backend/app/services/exercise_service.py
+++ b/backend/app/services/exercise_service.py
@@ -1,0 +1,45 @@
+"""Exercise domain services."""
+
+from __future__ import annotations
+
+from typing import Mapping, TYPE_CHECKING
+
+from sqlalchemy.exc import IntegrityError
+
+from app.core.errors import Conflict
+from app.repositories import ExerciseRepository
+
+from . import get_session
+
+if TYPE_CHECKING:  # pragma: no cover
+    from app.api.deps import Pagination
+
+
+class ExerciseService:
+    """Coordinate exercise catalogue operations."""
+
+    def __init__(self, session=None) -> None:
+        self.session = get_session(session)
+        self.repo = ExerciseRepository()
+
+    def list_exercises(self, filters: Mapping[str, object], pagination: "Pagination"):
+        """Return exercises filtered and paginated according to request parameters."""
+
+        return self.repo.query(
+            self.session,
+            filters,
+            page=pagination.page,
+            limit=pagination.limit,
+            sort=pagination.sort,
+        )
+
+    def create_exercise(self, data: Mapping[str, object]):
+        """Create a new exercise entry."""
+
+        try:
+            exercise = self.repo.create(self.session, data)
+            self.session.commit()
+        except IntegrityError as exc:  # pragma: no cover
+            self.session.rollback()
+            raise Conflict("Exercise already exists") from exc
+        return exercise

--- a/backend/app/services/routine_service.py
+++ b/backend/app/services/routine_service.py
@@ -1,0 +1,45 @@
+"""Routine domain services."""
+
+from __future__ import annotations
+
+from typing import Mapping, TYPE_CHECKING
+
+from sqlalchemy.exc import IntegrityError
+
+from app.core.errors import Conflict
+from app.repositories import RoutineRepository
+
+from . import get_session
+
+if TYPE_CHECKING:  # pragma: no cover
+    from app.api.deps import Pagination
+
+
+class RoutineService:
+    """Coordinate routine lifecycle operations."""
+
+    def __init__(self, session=None) -> None:
+        self.session = get_session(session)
+        self.repo = RoutineRepository()
+
+    def list_routines(self, filters: Mapping[str, object], pagination: "Pagination"):
+        """Return routines filtered and paginated according to request parameters."""
+
+        return self.repo.query(
+            self.session,
+            filters,
+            page=pagination.page,
+            limit=pagination.limit,
+            sort=pagination.sort,
+        )
+
+    def create_routine(self, data: Mapping[str, object]):
+        """Create a new routine record."""
+
+        try:
+            routine = self.repo.create(self.session, data)
+            self.session.commit()
+        except IntegrityError as exc:  # pragma: no cover
+            self.session.rollback()
+            raise Conflict("Routine already exists") from exc
+        return routine

--- a/backend/app/services/subject_service.py
+++ b/backend/app/services/subject_service.py
@@ -1,0 +1,45 @@
+"""Subject domain services."""
+
+from __future__ import annotations
+
+from typing import Mapping, TYPE_CHECKING
+
+from sqlalchemy.exc import IntegrityError
+
+from app.core.errors import Conflict
+from app.repositories import SubjectRepository
+
+from . import get_session
+
+if TYPE_CHECKING:  # pragma: no cover
+    from app.api.deps import Pagination
+
+
+class SubjectService:
+    """Coordinate subject lifecycle operations."""
+
+    def __init__(self, session=None) -> None:
+        self.session = get_session(session)
+        self.repo = SubjectRepository()
+
+    def list_subjects(self, filters: Mapping[str, object], pagination: "Pagination"):
+        """Return subjects filtered and paginated according to request parameters."""
+
+        return self.repo.query(
+            self.session,
+            filters,
+            page=pagination.page,
+            limit=pagination.limit,
+            sort=pagination.sort,
+        )
+
+    def create_subject(self, data: Mapping[str, object]):
+        """Create a new subject record."""
+
+        try:
+            subject = self.repo.create(self.session, data)
+            self.session.commit()
+        except IntegrityError as exc:  # pragma: no cover
+            self.session.rollback()
+            raise Conflict("Subject already exists") from exc
+        return subject

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,45 @@
+"""User domain services."""
+
+from __future__ import annotations
+
+from typing import Mapping, TYPE_CHECKING
+
+from sqlalchemy.exc import IntegrityError
+
+from app.core.errors import Conflict
+from app.repositories import UserRepository
+
+from . import get_session
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from app.api.deps import Pagination
+
+
+class UserService:
+    """Coordinate user-centric use cases."""
+
+    def __init__(self, session=None) -> None:
+        self.session = get_session(session)
+        self.repo = UserRepository()
+
+    def list_users(self, filters: Mapping[str, object], pagination: "Pagination"):
+        """Return users filtered and paginated according to request parameters."""
+
+        return self.repo.query(
+            self.session,
+            filters,
+            page=pagination.page,
+            limit=pagination.limit,
+            sort=pagination.sort,
+        )
+
+    def create_user(self, data: Mapping[str, object]):
+        """Create a new user and commit the transaction."""
+
+        try:
+            user = self.repo.create(self.session, data)
+            self.session.commit()
+        except IntegrityError as exc:  # pragma: no cover - DB dependent
+            self.session.rollback()
+            raise Conflict("User already exists") from exc
+        return user

--- a/backend/app/services/workout_service.py
+++ b/backend/app/services/workout_service.py
@@ -1,0 +1,45 @@
+"""Workout domain services."""
+
+from __future__ import annotations
+
+from typing import Mapping, TYPE_CHECKING
+
+from sqlalchemy.exc import IntegrityError
+
+from app.core.errors import Conflict
+from app.repositories import WorkoutRepository
+
+from . import get_session
+
+if TYPE_CHECKING:  # pragma: no cover
+    from app.api.deps import Pagination
+
+
+class WorkoutService:
+    """Coordinate workout session operations."""
+
+    def __init__(self, session=None) -> None:
+        self.session = get_session(session)
+        self.repo = WorkoutRepository()
+
+    def list_workouts(self, filters: Mapping[str, object], pagination: "Pagination"):
+        """Return workouts filtered and paginated according to request parameters."""
+
+        return self.repo.query(
+            self.session,
+            filters,
+            page=pagination.page,
+            limit=pagination.limit,
+            sort=pagination.sort,
+        )
+
+    def create_workout(self, data: Mapping[str, object]):
+        """Create a new workout session."""
+
+        try:
+            workout = self.repo.create(self.session, data)
+            self.session.commit()
+        except IntegrityError as exc:  # pragma: no cover
+            self.session.rollback()
+            raise Conflict("Workout already exists") from exc
+        return workout


### PR DESCRIPTION
## Summary
- add versioned v1 blueprint with thin controllers for auth, users, exercises, routines, workouts, subjects
- introduce marshmallow schemas, services, and repositories to isolate validation, domain logic, and persistence
- update core config, logging, and extensions for structured logging, caching, rate limiting, and JWT plumbing

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68e0643dfb1c8325a13e45054de43728