### PR TITLE
Use shared Pagination dataclass in API deps

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import functools
 import time
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 
 from flask import Response, current_app, g, jsonify, request
@@ -13,18 +12,9 @@ from sqlalchemy.orm import Query
 
 from app.core.errors import Unauthorized
 from app.core.extensions import db
+from app.repositories.base import Pagination
 
 F = TypeVar("F", bound=Callable[..., Any])
-
-
-@dataclass(slots=True)
-class Pagination:
-    """Parsed pagination parameters extracted from the query string."""
-
-    page: int
-    limit: int
-    sort: list[str]
-
 
 def parse_pagination(default_limit: int = 50, max_limit: int = 100) -> Pagination:
     """Parse ``page``, ``limit``, and ``sort`` query parameters.

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 import time
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
 from flask import Response, current_app, g, jsonify, request
@@ -14,6 +14,7 @@ from app.core.extensions import db
 from app.repositories.base import Pagination
 
 F = TypeVar("F", bound=Callable[..., Any])
+
 
 def parse_pagination(default_limit: int = 50, max_limit: int = 100) -> Pagination:
     """Parse ``page``, ``limit``, and ``sort`` query parameters.


### PR DESCRIPTION
## Summary
- import the shared Pagination dataclass from app.repositories.base in the API dependencies module
- remove the redundant local Pagination definition so pagination helpers use the shared type

## Testing
- pytest --override-ini addopts="" backend/app

------
https://chatgpt.com/codex/tasks/task_e_68e28b229b488325aa1a94207dd1422f